### PR TITLE
Propagate request contexts across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Example local Docker configuration:
 ```yaml
 server:
   port: 8080
+  request_timeout_seconds: 10
 
 database:
   host: "postgres"

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/spf13/viper"
 )
 
@@ -12,7 +15,16 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Port int `mapstructure:"port"`
+	Port                  int `mapstructure:"port"`
+	RequestTimeoutSeconds int `mapstructure:"request_timeout_seconds"`
+}
+
+func (s ServerConfig) RequestTimeout() time.Duration {
+	if s.RequestTimeoutSeconds <= 0 {
+		return 10 * time.Second
+	}
+
+	return time.Duration(s.RequestTimeoutSeconds) * time.Second
 }
 
 type DatabaseConfig struct {
@@ -35,18 +47,45 @@ type InfuraConfig struct {
 }
 
 func LoadConfig() (*Config, error) {
-	viper.SetConfigName("config")
-	viper.AddConfigPath("./config")
-	viper.SetConfigType("yaml")
+	v := viper.New()
+	v.SetConfigName("config")
+	v.AddConfigPath("./config")
+	v.SetConfigType("yaml")
 
-	if err := viper.ReadInConfig(); err != nil {
+	return loadConfig(v)
+}
+
+func loadConfig(v *viper.Viper) (*Config, error) {
+	if err := v.ReadInConfig(); err != nil {
 		return nil, err
 	}
 
+	v.Set("server.request_timeout_seconds", parseRequestTimeoutSeconds(v.Get("server.request_timeout_seconds")))
+
 	var config Config
-	if err := viper.Unmarshal(&config); err != nil {
+	if err := v.Unmarshal(&config); err != nil {
 		return nil, err
 	}
 
 	return &config, nil
+}
+
+func parseRequestTimeoutSeconds(value interface{}) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return 0
+		}
+
+		return parsed
+	default:
+		return 0
+	}
 }

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  request_timeout_seconds: 10
 
 database:
   host: "postgres"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerConfigRequestTimeoutDefaultsToTenSeconds(t *testing.T) {
+	cfg := ServerConfig{}
+
+	assert.Equal(t, 10*time.Second, cfg.RequestTimeout())
+}
+
+func TestServerConfigRequestTimeoutUsesConfiguredSeconds(t *testing.T) {
+	cfg := ServerConfig{RequestTimeoutSeconds: 3}
+
+	assert.Equal(t, 3*time.Second, cfg.RequestTimeout())
+}
+
+func TestLoadConfigDefaultsInvalidRequestTimeoutToTenSeconds(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(`
+server:
+  port: 8080
+  request_timeout_seconds: "invalid"
+`), 0600)
+	require.NoError(t, err)
+
+	v := viper.New()
+	v.SetConfigName("config")
+	v.AddConfigPath(dir)
+	v.SetConfigType("yaml")
+
+	cfg, err := loadConfig(v)
+
+	require.NoError(t, err)
+	assert.Equal(t, 10*time.Second, cfg.Server.RequestTimeout())
+}

--- a/controllers/campaign_controller.go
+++ b/controllers/campaign_controller.go
@@ -38,7 +38,7 @@ func NewCampaignController(config *config.Config, campaignService services.ICamp
 // @Failure 400 {object} map[string]interface{}
 // @Router /campaign/start [get]
 func (h *CampaignController) StartCampaign(ctx *gin.Context) {
-	if err := h.campaignService.StartCampaign(); err != nil {
+	if err := h.campaignService.StartCampaign(ctx.Request.Context()); err != nil {
 		ctx.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -59,7 +59,7 @@ func (h *CampaignController) StartCampaign(ctx *gin.Context) {
 func (h *CampaignController) GetPointHistories(ctx *gin.Context) {
 	address := ctx.Param("address")
 
-	pointHistories, err := h.campaignService.GetPointHistories(address)
+	pointHistories, err := h.campaignService.GetPointHistories(ctx.Request.Context(), address)
 	if err != nil {
 		ctx.JSON(500, gin.H{"status": "error", "message": err.Error()})
 		return
@@ -91,7 +91,7 @@ func (h *CampaignController) GetPointHistories(ctx *gin.Context) {
 func (h *CampaignController) GetTaskStatus(ctx *gin.Context) {
 	address := ctx.Param("address")
 
-	taskStatus, err := h.campaignService.GetTaskStatus(address)
+	taskStatus, err := h.campaignService.GetTaskStatus(ctx.Request.Context(), address)
 	if err != nil {
 		ctx.JSON(500, gin.H{"status": "error", "message": err.Error()})
 		return
@@ -125,7 +125,7 @@ func (h *CampaignController) GetLeaderboard(ctx *gin.Context) {
 		return
 	}
 
-	leaderboardEntries, err := h.campaignService.GetLeaderboard(taskName, int(period))
+	leaderboardEntries, err := h.campaignService.GetLeaderboard(ctx.Request.Context(), taskName, int(period))
 	if err != nil {
 		ctx.JSON(500, gin.H{"status": "error", "message": err.Error()})
 		return

--- a/controllers/campaign_controller_test.go
+++ b/controllers/campaign_controller_test.go
@@ -1,0 +1,37 @@
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"trading-ace/config"
+	"trading-ace/mocks"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestStartCampaignPassesRequestContextToService(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	campaignService := new(mocks.MockCampaignService)
+	controller := NewCampaignController(&config.Config{}, campaignService)
+	requestKey := struct{}{}
+	requestCtx := context.WithValue(context.Background(), requestKey, "request-context")
+
+	campaignService.On("StartCampaign", mock.MatchedBy(func(actual context.Context) bool {
+		return actual == requestCtx && actual.Value(requestKey) == "request-context"
+	})).Return(nil).Once()
+
+	w := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/campaign/start", nil)
+	ginCtx.Request = req.WithContext(requestCtx)
+
+	controller.StartCampaign(ginCtx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	campaignService.AssertExpectations(t)
+}

--- a/helpers/redis_helper.go
+++ b/helpers/redis_helper.go
@@ -10,20 +10,20 @@ import (
 )
 
 type IRedisHelper interface {
-	Set(key string, value string, expiration time.Duration) error
-	Get(key string) (string, error)
-	Delete(key string) error
-	IncrFloat(key string, value float64) error
-	HSet(key string, field string, value interface{}) error
-	HGet(key string, field string) (string, error)
-	HGetAll(key string) (map[string]string, error)
-	HIncrFloat(key string, field string, value float64) error
-	ZAdd(key string, members ...*redis.Z) error
-	ZRange(key string, start, stop int64) ([]string, error)
-	ZRangeWithScores(key string, start, stop int64) ([]string, []float64, error)
-	ZRevRange(key string, start, stop int64) ([]string, error)
-	ZRevRangeWithScores(key string, start, stop int64) ([]string, []float64, error)
-	SetTTL(key string, expiration time.Duration) error
+	Set(ctx context.Context, key string, value string, expiration time.Duration) error
+	Get(ctx context.Context, key string) (string, error)
+	Delete(ctx context.Context, key string) error
+	IncrFloat(ctx context.Context, key string, value float64) error
+	HSet(ctx context.Context, key string, field string, value interface{}) error
+	HGet(ctx context.Context, key string, field string) (string, error)
+	HGetAll(ctx context.Context, key string) (map[string]string, error)
+	HIncrFloat(ctx context.Context, key string, field string, value float64) error
+	ZAdd(ctx context.Context, key string, members ...*redis.Z) error
+	ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)
+	ZRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error)
+	ZRevRange(ctx context.Context, key string, start, stop int64) ([]string, error)
+	ZRevRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error)
+	SetTTL(ctx context.Context, key string, expiration time.Duration) error
 }
 
 type RedisHelper struct {
@@ -38,8 +38,8 @@ func NewRedisHelper(redisClient *redis.Client, config *config.Config) IRedisHelp
 	}
 }
 
-func (r *RedisHelper) Set(key string, value string, expiration time.Duration) error {
-	err := r.redisClient.Set(context.Background(), r.prefix+key, value, expiration).Err()
+func (r *RedisHelper) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
+	err := r.redisClient.Set(ctx, r.prefix+key, value, expiration).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set key %s: %w", key, err)
 	}
@@ -47,8 +47,8 @@ func (r *RedisHelper) Set(key string, value string, expiration time.Duration) er
 	return nil
 }
 
-func (r *RedisHelper) Get(key string) (string, error) {
-	val, err := r.redisClient.Get(context.Background(), r.prefix+key).Result()
+func (r *RedisHelper) Get(ctx context.Context, key string) (string, error) {
+	val, err := r.redisClient.Get(ctx, r.prefix+key).Result()
 	if err != nil {
 		if err == redis.Nil {
 			return "", fmt.Errorf("key %s does not exist", key)
@@ -60,8 +60,8 @@ func (r *RedisHelper) Get(key string) (string, error) {
 	return val, nil
 }
 
-func (r *RedisHelper) Delete(key string) error {
-	err := r.redisClient.Del(context.Background(), r.prefix+key).Err()
+func (r *RedisHelper) Delete(ctx context.Context, key string) error {
+	err := r.redisClient.Del(ctx, r.prefix+key).Err()
 	if err != nil {
 		return fmt.Errorf("failed to delete key %s: %w", key, err)
 	}
@@ -69,8 +69,8 @@ func (r *RedisHelper) Delete(key string) error {
 	return nil
 }
 
-func (r *RedisHelper) IncrFloat(key string, value float64) error {
-	err := r.redisClient.IncrByFloat(context.Background(), r.prefix+key, value).Err()
+func (r *RedisHelper) IncrFloat(ctx context.Context, key string, value float64) error {
+	err := r.redisClient.IncrByFloat(ctx, r.prefix+key, value).Err()
 	if err != nil {
 		return fmt.Errorf("failed to IncrFloat key %s: %w", key, err)
 	}
@@ -78,8 +78,8 @@ func (r *RedisHelper) IncrFloat(key string, value float64) error {
 	return nil
 }
 
-func (r *RedisHelper) HSet(key string, field string, value interface{}) error {
-	err := r.redisClient.HSet(context.Background(), r.prefix+key, field, value).Err()
+func (r *RedisHelper) HSet(ctx context.Context, key string, field string, value interface{}) error {
+	err := r.redisClient.HSet(ctx, r.prefix+key, field, value).Err()
 	if err != nil {
 		return fmt.Errorf("failed to HSET field %s in key %s: %w", field, key, err)
 	}
@@ -87,8 +87,8 @@ func (r *RedisHelper) HSet(key string, field string, value interface{}) error {
 	return nil
 }
 
-func (r *RedisHelper) HGet(key string, field string) (string, error) {
-	val, err := r.redisClient.HGet(context.Background(), r.prefix+key, field).Result()
+func (r *RedisHelper) HGet(ctx context.Context, key string, field string) (string, error) {
+	val, err := r.redisClient.HGet(ctx, r.prefix+key, field).Result()
 	if err != nil {
 		if err == redis.Nil {
 			return "", fmt.Errorf("field %s does not exist in key %s", field, key)
@@ -100,8 +100,8 @@ func (r *RedisHelper) HGet(key string, field string) (string, error) {
 	return val, nil
 }
 
-func (r *RedisHelper) HGetAll(key string) (map[string]string, error) {
-	result, err := r.redisClient.HGetAll(context.Background(), r.prefix+key).Result()
+func (r *RedisHelper) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	result, err := r.redisClient.HGetAll(ctx, r.prefix+key).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +109,8 @@ func (r *RedisHelper) HGetAll(key string) (map[string]string, error) {
 	return result, nil
 }
 
-func (r *RedisHelper) HIncrFloat(key string, field string, value float64) error {
-	err := r.redisClient.HIncrByFloat(context.Background(), r.prefix+key, field, value).Err()
+func (r *RedisHelper) HIncrFloat(ctx context.Context, key string, field string, value float64) error {
+	err := r.redisClient.HIncrByFloat(ctx, r.prefix+key, field, value).Err()
 	if err != nil {
 		return fmt.Errorf("failed to HIncrFloat field %s in key %s: %w", field, key, err)
 	}
@@ -118,8 +118,8 @@ func (r *RedisHelper) HIncrFloat(key string, field string, value float64) error 
 	return nil
 }
 
-func (r *RedisHelper) ZAdd(key string, members ...*redis.Z) error {
-	err := r.redisClient.ZAdd(context.Background(), r.prefix+key, members...).Err()
+func (r *RedisHelper) ZAdd(ctx context.Context, key string, members ...*redis.Z) error {
+	err := r.redisClient.ZAdd(ctx, r.prefix+key, members...).Err()
 	if err != nil {
 		return fmt.Errorf("failed to ZADD to key %s: %w", key, err)
 	}
@@ -127,8 +127,8 @@ func (r *RedisHelper) ZAdd(key string, members ...*redis.Z) error {
 	return nil
 }
 
-func (r *RedisHelper) ZRange(key string, start, stop int64) ([]string, error) {
-	vals, err := r.redisClient.ZRange(context.Background(), r.prefix+key, start, stop).Result()
+func (r *RedisHelper) ZRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
+	vals, err := r.redisClient.ZRange(ctx, r.prefix+key, start, stop).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to ZRANGE key %s: %w", key, err)
 	}
@@ -136,8 +136,8 @@ func (r *RedisHelper) ZRange(key string, start, stop int64) ([]string, error) {
 	return vals, nil
 }
 
-func (r *RedisHelper) ZRangeWithScores(key string, start, stop int64) ([]string, []float64, error) {
-	result, err := r.redisClient.ZRangeWithScores(context.Background(), r.prefix+key, start, stop).Result()
+func (r *RedisHelper) ZRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error) {
+	result, err := r.redisClient.ZRangeWithScores(ctx, r.prefix+key, start, stop).Result()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get range with scores from ZSET %s: %w", key, err)
 	}
@@ -153,8 +153,8 @@ func (r *RedisHelper) ZRangeWithScores(key string, start, stop int64) ([]string,
 	return values, scores, nil
 }
 
-func (r *RedisHelper) ZRevRange(key string, start, stop int64) ([]string, error) {
-	vals, err := r.redisClient.ZRevRange(context.Background(), r.prefix+key, start, stop).Result()
+func (r *RedisHelper) ZRevRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
+	vals, err := r.redisClient.ZRevRange(ctx, r.prefix+key, start, stop).Result()
 	if err != nil {
 		return nil, fmt.Errorf("failed to ZRANGE key %s: %w", key, err)
 	}
@@ -162,8 +162,8 @@ func (r *RedisHelper) ZRevRange(key string, start, stop int64) ([]string, error)
 	return vals, nil
 }
 
-func (r *RedisHelper) ZRevRangeWithScores(key string, start, stop int64) ([]string, []float64, error) {
-	result, err := r.redisClient.ZRevRangeWithScores(context.Background(), r.prefix+key, start, stop).Result()
+func (r *RedisHelper) ZRevRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error) {
+	result, err := r.redisClient.ZRevRangeWithScores(ctx, r.prefix+key, start, stop).Result()
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get range with scores from ZSET %s: %w", key, err)
 	}
@@ -179,8 +179,8 @@ func (r *RedisHelper) ZRevRangeWithScores(key string, start, stop int64) ([]stri
 	return values, scores, nil
 }
 
-func (r *RedisHelper) SetTTL(key string, expiration time.Duration) error {
-	err := r.redisClient.Expire(context.Background(), r.prefix+key, expiration).Err()
+func (r *RedisHelper) SetTTL(ctx context.Context, key string, expiration time.Duration) error {
+	err := r.redisClient.Expire(ctx, r.prefix+key, expiration).Err()
 	if err != nil {
 		return fmt.Errorf("failed to set key %s: %w", key, err)
 	}

--- a/helpers/redis_helper_test.go
+++ b/helpers/redis_helper_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -28,13 +29,13 @@ func TestRedisHelper_Set(t *testing.T) {
 
 	mock.ExpectSet("test:"+key, value, expiration).SetVal("OK")
 
-	err := r.Set(key, value, expiration)
+	err := r.Set(context.Background(), key, value, expiration)
 	assert.NoError(t, err)
 
 	// Simulate failure
 	mock.ExpectSet("test:"+key, value, expiration).SetErr(errors.New("redis error"))
 
-	err = r.Set(key, value, expiration)
+	err = r.Set(context.Background(), key, value, expiration)
 	assert.Error(t, err)
 }
 
@@ -46,20 +47,20 @@ func TestRedisHelper_Get(t *testing.T) {
 
 	mock.ExpectGet("test:" + key).SetVal(expected)
 
-	val, err := r.Get(key)
+	val, err := r.Get(context.Background(), key)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 
 	// Simulate key does not exist
 	mock.ExpectGet("test:" + key).RedisNil()
 
-	_, err = r.Get(key)
+	_, err = r.Get(context.Background(), key)
 	assert.Error(t, err)
 
 	// Simulate redis error
 	mock.ExpectGet("test:" + key).SetErr(errors.New("redis error"))
 
-	_, err = r.Get(key)
+	_, err = r.Get(context.Background(), key)
 	assert.Error(t, err)
 }
 
@@ -70,13 +71,13 @@ func TestRedisHelper_Delete(t *testing.T) {
 
 	mock.ExpectDel("test:" + key).SetVal(1)
 
-	err := r.Delete(key)
+	err := r.Delete(context.Background(), key)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectDel("test:" + key).SetErr(errors.New("redis error"))
 
-	err = r.Delete(key)
+	err = r.Delete(context.Background(), key)
 	assert.Error(t, err)
 }
 
@@ -88,13 +89,13 @@ func TestRedisHelper_IncrFloat(t *testing.T) {
 
 	mock.ExpectIncrByFloat("test:"+key, increment).SetVal(2.5)
 
-	err := r.IncrFloat(key, increment)
+	err := r.IncrFloat(context.Background(), key, increment)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectIncrByFloat("test:"+key, increment).SetErr(errors.New("redis error"))
 
-	err = r.IncrFloat(key, increment)
+	err = r.IncrFloat(context.Background(), key, increment)
 	assert.Error(t, err)
 }
 
@@ -107,13 +108,13 @@ func TestRedisHelper_HSet(t *testing.T) {
 
 	mock.ExpectHSet("test:"+key, field, value).SetVal(1)
 
-	err := r.HSet(key, field, value)
+	err := r.HSet(context.Background(), key, field, value)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectHSet("test:"+key, field, value).SetErr(errors.New("redis error"))
 
-	err = r.HSet(key, field, value)
+	err = r.HSet(context.Background(), key, field, value)
 	assert.Error(t, err)
 }
 
@@ -126,20 +127,20 @@ func TestRedisHelper_HGet(t *testing.T) {
 
 	mock.ExpectHGet("test:"+key, field).SetVal(expected)
 
-	val, err := r.HGet(key, field)
+	val, err := r.HGet(context.Background(), key, field)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, val)
 
 	// Simulate field does not exist
 	mock.ExpectHGet("test:"+key, field).RedisNil()
 
-	_, err = r.HGet(key, field)
+	_, err = r.HGet(context.Background(), key, field)
 	assert.Error(t, err)
 
 	// Simulate redis error
 	mock.ExpectHGet("test:"+key, field).SetErr(errors.New("redis error"))
 
-	_, err = r.HGet(key, field)
+	_, err = r.HGet(context.Background(), key, field)
 	assert.Error(t, err)
 }
 
@@ -152,13 +153,13 @@ func TestRedisHelper_HIncrFloat(t *testing.T) {
 
 	mock.ExpectHIncrByFloat("test:"+key, field, increment).SetVal(2.5)
 
-	err := r.HIncrFloat(key, field, increment)
+	err := r.HIncrFloat(context.Background(), key, field, increment)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectHIncrByFloat("test:"+key, field, increment).SetErr(errors.New("redis error"))
 
-	err = r.HIncrFloat(key, field, increment)
+	err = r.HIncrFloat(context.Background(), key, field, increment)
 	assert.Error(t, err)
 }
 
@@ -170,13 +171,13 @@ func TestRedisHelper_ZAdd(t *testing.T) {
 
 	mock.ExpectZAdd("test:"+key, &member).SetVal(1)
 
-	err := r.ZAdd(key, &member)
+	err := r.ZAdd(context.Background(), key, &member)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectZAdd("test:"+key, &member).SetErr(errors.New("redis error"))
 
-	err = r.ZAdd(key, &member)
+	err = r.ZAdd(context.Background(), key, &member)
 	assert.Error(t, err)
 }
 
@@ -188,14 +189,14 @@ func TestRedisHelper_ZRange(t *testing.T) {
 
 	mock.ExpectZRange("test:"+key, 0, -1).SetVal(expected)
 
-	vals, err := r.ZRange(key, 0, -1)
+	vals, err := r.ZRange(context.Background(), key, 0, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, vals)
 
 	// Simulate redis error
 	mock.ExpectZRange("test:"+key, 0, -1).SetErr(errors.New("redis error"))
 
-	_, err = r.ZRange(key, 0, -1)
+	_, err = r.ZRange(context.Background(), key, 0, -1)
 	assert.Error(t, err)
 }
 
@@ -207,13 +208,13 @@ func TestRedisHelper_SetTTL(t *testing.T) {
 
 	mock.ExpectExpire("test:"+key, expiration).SetVal(true)
 
-	err := r.SetTTL(key, expiration)
+	err := r.SetTTL(context.Background(), key, expiration)
 	assert.NoError(t, err)
 
 	// Simulate redis error
 	mock.ExpectExpire("test:"+key, expiration).SetErr(errors.New("redis error"))
 
-	err = r.SetTTL(key, expiration)
+	err = r.SetTTL(context.Background(), key, expiration)
 	assert.Error(t, err)
 }
 
@@ -232,7 +233,7 @@ func TestRedisHelper_HGetAll(t *testing.T) {
 	mock.ExpectHGetAll("test:" + key).SetVal(expectedResult)
 
 	// 呼叫 HGetAll 方法
-	result, err := r.HGetAll(key)
+	result, err := r.HGetAll(context.Background(), key)
 
 	// 驗證結果
 	assert.NoError(t, err)
@@ -242,7 +243,7 @@ func TestRedisHelper_HGetAll(t *testing.T) {
 	mock.ExpectHGetAll("test:" + key).SetErr(errors.New("redis error"))
 
 	// 再次呼叫 HGetAll 並檢查錯誤
-	result, err = r.HGetAll(key)
+	result, err = r.HGetAll(context.Background(), key)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -263,7 +264,7 @@ func TestRedisHelper_ZRangeWithScores(t *testing.T) {
 	})
 
 	// 測試方法
-	values, scores, err := r.ZRangeWithScores(key, start, stop)
+	values, scores, err := r.ZRangeWithScores(context.Background(), key, start, stop)
 
 	// 驗證
 	assert.NoError(t, err)
@@ -274,7 +275,7 @@ func TestRedisHelper_ZRangeWithScores(t *testing.T) {
 	mock.ExpectZRangeWithScores("test:"+key, start, stop).SetErr(errors.New("redis error"))
 
 	// 測試錯誤情況
-	values, scores, err = r.ZRangeWithScores(key, start, stop)
+	values, scores, err = r.ZRangeWithScores(context.Background(), key, start, stop)
 	assert.Error(t, err)
 	assert.Nil(t, values)
 	assert.Nil(t, scores)
@@ -291,7 +292,7 @@ func TestRedisHelper_ZRevRange(t *testing.T) {
 	mock.ExpectZRevRange("test:"+key, start, stop).SetVal(expectedValues)
 
 	// 測試方法
-	result, err := r.ZRevRange(key, start, stop)
+	result, err := r.ZRevRange(context.Background(), key, start, stop)
 
 	// 驗證
 	assert.NoError(t, err)
@@ -301,7 +302,7 @@ func TestRedisHelper_ZRevRange(t *testing.T) {
 	mock.ExpectZRevRange("test:"+key, start, stop).SetErr(errors.New("redis error"))
 
 	// 測試錯誤情況
-	result, err = r.ZRevRange(key, start, stop)
+	result, err = r.ZRevRange(context.Background(), key, start, stop)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
@@ -322,7 +323,7 @@ func TestRedisHelper_ZRevRangeWithScores(t *testing.T) {
 	})
 
 	// 測試方法
-	values, scores, err := r.ZRevRangeWithScores(key, start, stop)
+	values, scores, err := r.ZRevRangeWithScores(context.Background(), key, start, stop)
 
 	// 驗證結果
 	assert.NoError(t, err)
@@ -333,7 +334,7 @@ func TestRedisHelper_ZRevRangeWithScores(t *testing.T) {
 	mock.ExpectZRevRangeWithScores("test:"+key, start, stop).SetErr(errors.New("redis error"))
 
 	// 測試錯誤情況
-	values, scores, err = r.ZRevRangeWithScores(key, start, stop)
+	values, scores, err = r.ZRevRangeWithScores(context.Background(), key, start, stop)
 	assert.Error(t, err)
 	assert.Nil(t, values)
 	assert.Nil(t, scores)

--- a/main.go
+++ b/main.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
+	"net/http"
+	"time"
 	"trading-ace/config"
 	"trading-ace/controllers"
 	"trading-ace/helpers"
 	"trading-ace/logger"
+	"trading-ace/middlewares"
 	"trading-ace/repositories"
 	"trading-ace/routes"
 	"trading-ace/services"
@@ -19,7 +23,7 @@ import (
 	"go.uber.org/fx"
 )
 
-var ctx = context.Background()
+const startupTimeout = 10 * time.Second
 
 func NewDB(config *config.Config) (*sql.DB, error) {
 	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
@@ -36,7 +40,10 @@ func NewDB(config *config.Config) (*sql.DB, error) {
 		return nil, err
 	}
 
-	if err := db.Ping(); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), startupTimeout)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
 		return nil, err
 	}
 
@@ -50,6 +57,9 @@ func NewRedis(config *config.Config) (*redis.Client, error) {
 		DB:       0,
 	})
 
+	ctx, cancel := context.WithTimeout(context.Background(), startupTimeout)
+	defer cancel()
+
 	_, err := rdb.Ping(ctx).Result()
 	if err != nil {
 		return nil, err
@@ -58,12 +68,28 @@ func NewRedis(config *config.Config) (*redis.Client, error) {
 	return rdb, nil
 }
 
-func NewGinServer() *gin.Engine {
+func NewGinServer(config *config.Config) *gin.Engine {
 	r := gin.Default()
+	r.Use(middlewares.Timeout(config.Server.RequestTimeout()))
 	return r
 }
 
+func NewAppContext(lc fx.Lifecycle) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	lc.Append(fx.Hook{
+		OnStop: func(context.Context) error {
+			cancel()
+			return nil
+		},
+	})
+
+	return ctx
+}
+
 func SetupServer(
+	lc fx.Lifecycle,
+	appCtx context.Context,
 	r *gin.Engine,
 	logger logger.ILogger,
 	config *config.Config,
@@ -71,16 +97,49 @@ func SetupServer(
 	homeRoutes routes.IHomeRoutes,
 	campaignRoutes routes.ICampaignRoutes,
 ) {
-	go ethereumService.SubscribeEthereumSwap()
-
 	homeRoutes.RegisterHomeRoutes()
 	campaignRoutes.RegisterCampaignRoutes()
 
-	r.Run(fmt.Sprintf(":%d", config.Server.Port))
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", config.Server.Port),
+		Handler: r,
+	}
+
+	ethereumCtx, cancelEthereum := context.WithCancel(appCtx)
+
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			listener, err := net.Listen("tcp", server.Addr)
+			if err != nil {
+				cancelEthereum()
+				return fmt.Errorf("failed to listen on %s: %w", server.Addr, err)
+			}
+
+			go func() {
+				if err := ethereumService.SubscribeEthereumSwap(ethereumCtx); err != nil {
+					logger.Error("Ethereum swap subscription stopped: %v", err)
+				}
+			}()
+
+			go func() {
+				if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+					logger.Error("HTTP server stopped unexpectedly: %v", err)
+				}
+			}()
+
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			cancelEthereum()
+			return server.Shutdown(ctx)
+		},
+	})
 }
 
 func main() {
 	app := fx.New(
+		fx.StartTimeout(startupTimeout),
+		fx.StopTimeout(startupTimeout),
 		fx.Provide(
 
 			// Base
@@ -108,9 +167,10 @@ func main() {
 
 			// Helper
 			helpers.NewRedisHelper,
+			NewAppContext,
 		),
 		fx.Invoke(SetupServer),
 	)
 
-	app.Start(ctx)
+	app.Run()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+	"trading-ace/config"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestNewGinServerUsesConfiguredRequestTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := NewGinServer(&config.Config{
+		Server: config.ServerConfig{
+			RequestTimeoutSeconds: 2,
+		},
+	})
+
+	router.GET("/deadline", func(c *gin.Context) {
+		deadline, ok := c.Request.Context().Deadline()
+		require.True(t, ok)
+		assert.LessOrEqual(t, time.Until(deadline), 2*time.Second)
+		assert.Greater(t, time.Until(deadline), time.Second)
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deadline", nil)
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestNewAppContextCancelsOnLifecycleStop(t *testing.T) {
+	lifecycle := fxtest.NewLifecycle(t)
+
+	ctx := NewAppContext(lifecycle)
+
+	require.NoError(t, lifecycle.Start(contextWithTimeout(t)))
+	assert.NoError(t, ctx.Err())
+
+	require.NoError(t, lifecycle.Stop(contextWithTimeout(t)))
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func contextWithTimeout(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/middlewares/timeout.go
+++ b/middlewares/timeout.go
@@ -1,0 +1,18 @@
+package middlewares
+
+import (
+	"context"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Timeout(timeout time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+		defer cancel()
+
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}

--- a/middlewares/timeout_test.go
+++ b/middlewares/timeout_test.go
@@ -1,0 +1,33 @@
+package middlewares
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeoutAddsDeadlineToRequestContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(Timeout(10 * time.Second))
+
+	router.GET("/deadline", func(c *gin.Context) {
+		deadline, ok := c.Request.Context().Deadline()
+		require.True(t, ok)
+		assert.LessOrEqual(t, time.Until(deadline), 10*time.Second)
+		assert.Greater(t, time.Until(deadline), 9*time.Second)
+		c.Status(http.StatusNoContent)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/deadline", nil)
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}

--- a/mocks/campaign_service.go
+++ b/mocks/campaign_service.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"trading-ace/entities"
 	"trading-ace/models"
 
@@ -11,37 +12,37 @@ type MockCampaignService struct {
 	mock.Mock
 }
 
-func (m *MockCampaignService) StartCampaign() error {
-	args := m.Called()
+func (m *MockCampaignService) StartCampaign(ctx context.Context) error {
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 
-func (m *MockCampaignService) GetPointHistories(address string) ([]*models.TaskTaskHistoryPair, error) {
-	args := m.Called(address)
+func (m *MockCampaignService) GetPointHistories(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error) {
+	args := m.Called(ctx, address)
 	return args.Get(0).([]*models.TaskTaskHistoryPair), args.Error(1)
 }
 
-func (m *MockCampaignService) RecordUSDCSwapTotalAmount(senderAddress string, amount float64) (float64, error) {
-	args := m.Called(senderAddress, amount)
+func (m *MockCampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error) {
+	args := m.Called(ctx, senderAddress, amount)
 	return args.Get(0).(float64), args.Error(1)
 }
 
-func (m *MockCampaignService) GetTaskStatus(address string) ([]*models.TaskWithTaskHistory, error) {
-	args := m.Called(address)
+func (m *MockCampaignService) GetTaskStatus(ctx context.Context, address string) ([]*models.TaskWithTaskHistory, error) {
+	args := m.Called(ctx, address)
 	return args.Get(0).([]*models.TaskWithTaskHistory), args.Error(1)
 }
 
-func (m *MockCampaignService) FindOnboardingTask() (*entities.Task, error) {
-	args := m.Called()
+func (m *MockCampaignService) FindOnboardingTask(ctx context.Context) (*entities.Task, error) {
+	args := m.Called(ctx)
 	return args.Get(0).(*entities.Task), args.Error(1)
 }
 
-func (m *MockCampaignService) FindCurrentSharePoolTask() (*entities.Task, error) {
-	args := m.Called()
+func (m *MockCampaignService) FindCurrentSharePoolTask(ctx context.Context) (*entities.Task, error) {
+	args := m.Called(ctx)
 	return args.Get(0).(*entities.Task), args.Error(1)
 }
 
-func (m *MockCampaignService) GetLeaderboard(taskName string, period int) ([]models.LeaderboardEntry, error) {
-	args := m.Called()
+func (m *MockCampaignService) GetLeaderboard(ctx context.Context, taskName string, period int) ([]models.LeaderboardEntry, error) {
+	args := m.Called(ctx, taskName, period)
 	return args.Get(0).([]models.LeaderboardEntry), args.Error(1)
 }

--- a/mocks/redis_helper.go
+++ b/mocks/redis_helper.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -12,72 +13,72 @@ type MockRedisHelper struct {
 	mock.Mock
 }
 
-func (m *MockRedisHelper) Set(key string, value string, expiration time.Duration) error {
-	args := m.Called(key, value, expiration)
+func (m *MockRedisHelper) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
+	args := m.Called(ctx, key, value, expiration)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) Get(key string) (string, error) {
-	args := m.Called(key)
+func (m *MockRedisHelper) Get(ctx context.Context, key string) (string, error) {
+	args := m.Called(ctx, key)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockRedisHelper) Delete(key string) error {
-	args := m.Called(key)
+func (m *MockRedisHelper) Delete(ctx context.Context, key string) error {
+	args := m.Called(ctx, key)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) IncrFloat(key string, value float64) error {
-	args := m.Called(key, value)
+func (m *MockRedisHelper) IncrFloat(ctx context.Context, key string, value float64) error {
+	args := m.Called(ctx, key, value)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) HSet(key string, field string, value interface{}) error {
-	args := m.Called(key, field, value)
+func (m *MockRedisHelper) HSet(ctx context.Context, key string, field string, value interface{}) error {
+	args := m.Called(ctx, key, field, value)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) HGet(key string, field string) (string, error) {
-	args := m.Called(key, field)
+func (m *MockRedisHelper) HGet(ctx context.Context, key string, field string) (string, error) {
+	args := m.Called(ctx, key, field)
 	return args.String(0), args.Error(1)
 }
 
-func (m *MockRedisHelper) HGetAll(key string) (map[string]string, error) {
-	args := m.Called(key)
+func (m *MockRedisHelper) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	args := m.Called(ctx, key)
 	return args.Get(0).(map[string]string), args.Error(1)
 }
 
-func (m *MockRedisHelper) HIncrFloat(key string, field string, value float64) error {
-	args := m.Called(key, field, value)
+func (m *MockRedisHelper) HIncrFloat(ctx context.Context, key string, field string, value float64) error {
+	args := m.Called(ctx, key, field, value)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) ZAdd(key string, members ...*redis.Z) error {
-	args := m.Called(key, members)
+func (m *MockRedisHelper) ZAdd(ctx context.Context, key string, members ...*redis.Z) error {
+	args := m.Called(ctx, key, members)
 	return args.Error(0)
 }
 
-func (m *MockRedisHelper) ZRange(key string, start, stop int64) ([]string, error) {
-	args := m.Called(key, start, stop)
+func (m *MockRedisHelper) ZRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
+	args := m.Called(ctx, key, start, stop)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *MockRedisHelper) ZRangeWithScores(key string, start, stop int64) ([]string, []float64, error) {
-	args := m.Called(key, start, stop)
+func (m *MockRedisHelper) ZRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error) {
+	args := m.Called(ctx, key, start, stop)
 	return args.Get(0).([]string), args.Get(1).([]float64), args.Error(2)
 }
 
-func (m *MockRedisHelper) ZRevRange(key string, start, stop int64) ([]string, error) {
-	args := m.Called(key, start, stop)
+func (m *MockRedisHelper) ZRevRange(ctx context.Context, key string, start, stop int64) ([]string, error) {
+	args := m.Called(ctx, key, start, stop)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *MockRedisHelper) ZRevRangeWithScores(key string, start, stop int64) ([]string, []float64, error) {
-	args := m.Called(key, start, stop)
+func (m *MockRedisHelper) ZRevRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error) {
+	args := m.Called(ctx, key, start, stop)
 	return args.Get(0).([]string), args.Get(1).([]float64), args.Error(2)
 }
 
-func (m *MockRedisHelper) SetTTL(key string, expiration time.Duration) error {
-	args := m.Called(key, expiration)
+func (m *MockRedisHelper) SetTTL(ctx context.Context, key string, expiration time.Duration) error {
+	args := m.Called(ctx, key, expiration)
 	return args.Error(0)
 }

--- a/mocks/task_history_repository.go
+++ b/mocks/task_history_repository.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"trading-ace/entities"
 	"trading-ace/models"
 
@@ -11,23 +12,23 @@ type MockTaskHistoryRepository struct {
 	mock.Mock
 }
 
-func (m *MockTaskHistoryRepository) Create(taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
-	args := m.Called(taskHistory)
+func (m *MockTaskHistoryRepository) Create(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
+	args := m.Called(ctx, taskHistory)
 	return getTaskHistory(args, 0), args.Error(1)
 }
 
-func (m *MockTaskHistoryRepository) FindByID(id int64) (*entities.TaskHistory, error) {
-	args := m.Called(id)
+func (m *MockTaskHistoryRepository) FindByID(ctx context.Context, id int64) (*entities.TaskHistory, error) {
+	args := m.Called(ctx, id)
 	return getTaskHistory(args, 0), args.Error(1)
 }
 
-func (m *MockTaskHistoryRepository) FindByAddressAndTaskId(address string, taskId int64) (*entities.TaskHistory, error) {
-	args := m.Called(address, taskId)
+func (m *MockTaskHistoryRepository) FindByAddressAndTaskId(ctx context.Context, address string, taskId int64) (*entities.TaskHistory, error) {
+	args := m.Called(ctx, address, taskId)
 	return getTaskHistory(args, 0), args.Error(1)
 }
 
-func (m *MockTaskHistoryRepository) GetByAddressIncludingTasks(address string) ([]*models.TaskTaskHistoryPair, error) {
-	args := m.Called(address)
+func (m *MockTaskHistoryRepository) GetByAddressIncludingTasks(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error) {
+	args := m.Called(ctx, address)
 	return args.Get(0).([]*models.TaskTaskHistoryPair), args.Error(1)
 }
 

--- a/mocks/task_repository.go
+++ b/mocks/task_repository.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"trading-ace/entities"
 	"trading-ace/models"
 
@@ -11,32 +12,32 @@ type MockTaskRepository struct {
 	mock.Mock
 }
 
-func (m *MockTaskRepository) Create(task *entities.Task) (*entities.Task, error) {
-	args := m.Called(task)
+func (m *MockTaskRepository) Create(ctx context.Context, task *entities.Task) (*entities.Task, error) {
+	args := m.Called(ctx, task)
 	return args.Get(0).(*entities.Task), args.Error(1)
 }
 
-func (m *MockTaskRepository) FindById(id int64) (*entities.Task, error) {
-	args := m.Called(id)
+func (m *MockTaskRepository) FindById(ctx context.Context, id int64) (*entities.Task, error) {
+	args := m.Called(ctx, id)
 	return args.Get(0).(*entities.Task), args.Error(1)
 }
 
-func (m *MockTaskRepository) FindByName(name string) (*entities.Task, error) {
-	args := m.Called(name)
+func (m *MockTaskRepository) FindByName(ctx context.Context, name string) (*entities.Task, error) {
+	args := m.Called(ctx, name)
 	return args.Get(0).(*entities.Task), args.Error(1)
 }
 
-func (m *MockTaskRepository) GetByName(name string) ([]*entities.Task, error) {
-	args := m.Called(name)
+func (m *MockTaskRepository) GetByName(ctx context.Context, name string) ([]*entities.Task, error) {
+	args := m.Called(ctx, name)
 	return args.Get(0).([]*entities.Task), args.Error(1)
 }
 
-func (m *MockTaskRepository) IsExistedByName(name string) (bool, error) {
-	args := m.Called(name)
+func (m *MockTaskRepository) IsExistedByName(ctx context.Context, name string) (bool, error) {
+	args := m.Called(ctx, name)
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *MockTaskRepository) GetByAddressAndNamesIncludingTaskHistories(address string, names []string) ([]*models.TaskWithTaskHistory, error) {
-	args := m.Called(address, names)
+func (m *MockTaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error) {
+	args := m.Called(ctx, address, names)
 	return args.Get(0).([]*models.TaskWithTaskHistory), args.Error(1)
 }

--- a/repositories/task_history_repository.go
+++ b/repositories/task_history_repository.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"trading-ace/entities"
@@ -8,10 +9,10 @@ import (
 )
 
 type ITaskHistoryRepository interface {
-	Create(taskHistory *entities.TaskHistory) (*entities.TaskHistory, error)
-	FindByID(id int64) (*entities.TaskHistory, error)
-	FindByAddressAndTaskId(address string, taskId int64) (*entities.TaskHistory, error)
-	GetByAddressIncludingTasks(address string) ([]*models.TaskTaskHistoryPair, error)
+	Create(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error)
+	FindByID(ctx context.Context, id int64) (*entities.TaskHistory, error)
+	FindByAddressAndTaskId(ctx context.Context, address string, taskId int64) (*entities.TaskHistory, error)
+	GetByAddressIncludingTasks(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error)
 }
 
 type TaskHistoryRepository struct {
@@ -24,7 +25,7 @@ func NewTaskHistoryRepository(db *sql.DB) ITaskHistoryRepository {
 	}
 }
 
-func (r *TaskHistoryRepository) Create(taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
+func (r *TaskHistoryRepository) Create(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
 	query := `
 		INSERT INTO task_histories (address, task_id, reward_points, amount, completed_at, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
@@ -33,7 +34,8 @@ func (r *TaskHistoryRepository) Create(taskHistory *entities.TaskHistory) (*enti
 
 	var result entities.TaskHistory
 
-	err := r.db.QueryRow(
+	err := r.db.QueryRowContext(
+		ctx,
 		query,
 		taskHistory.Address, taskHistory.TaskID, taskHistory.RewardPoints,
 		taskHistory.Amount, taskHistory.CompletedAt,
@@ -49,7 +51,7 @@ func (r *TaskHistoryRepository) Create(taskHistory *entities.TaskHistory) (*enti
 	return &result, nil
 }
 
-func (r *TaskHistoryRepository) FindByID(id int64) (*entities.TaskHistory, error) {
+func (r *TaskHistoryRepository) FindByID(ctx context.Context, id int64) (*entities.TaskHistory, error) {
 	query := `
 		SELECT id, address, task_id, reward_points, amount, completed_at, created_at, updated_at
 		FROM task_histories
@@ -57,7 +59,7 @@ func (r *TaskHistoryRepository) FindByID(id int64) (*entities.TaskHistory, error
 	`
 
 	var result entities.TaskHistory
-	err := r.db.QueryRow(query, id).Scan(
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
 		&result.ID, &result.Address, &result.TaskID, &result.RewardPoints,
 		&result.Amount, &result.CompletedAt, &result.CreatedAt, &result.UpdatedAt,
 	)
@@ -73,7 +75,7 @@ func (r *TaskHistoryRepository) FindByID(id int64) (*entities.TaskHistory, error
 	return &result, nil
 }
 
-func (r *TaskHistoryRepository) FindByAddressAndTaskId(address string, taskId int64) (*entities.TaskHistory, error) {
+func (r *TaskHistoryRepository) FindByAddressAndTaskId(ctx context.Context, address string, taskId int64) (*entities.TaskHistory, error) {
 	query := `
 		SELECT id, address, task_id, reward_points, amount, completed_at, created_at, updated_at
 		FROM task_histories
@@ -81,7 +83,7 @@ func (r *TaskHistoryRepository) FindByAddressAndTaskId(address string, taskId in
 	`
 
 	var result entities.TaskHistory
-	err := r.db.QueryRow(query, address, taskId).Scan(
+	err := r.db.QueryRowContext(ctx, query, address, taskId).Scan(
 		&result.ID, &result.Address, &result.TaskID, &result.RewardPoints,
 		&result.Amount, &result.CompletedAt, &result.CreatedAt, &result.UpdatedAt,
 	)
@@ -97,7 +99,7 @@ func (r *TaskHistoryRepository) FindByAddressAndTaskId(address string, taskId in
 	return &result, nil
 }
 
-func (t *TaskHistoryRepository) GetByAddressIncludingTasks(address string) ([]*models.TaskTaskHistoryPair, error) {
+func (t *TaskHistoryRepository) GetByAddressIncludingTasks(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error) {
 	query := `
 		SELECT th.id, th.address, th.reward_points, th.amount, th.completed_at,
 		       t.id, t.name, t.description, t.points, t.started_at, t.end_at, t.period, t.created_at, t.updated_at
@@ -106,7 +108,7 @@ func (t *TaskHistoryRepository) GetByAddressIncludingTasks(address string) ([]*m
 		WHERE th.address = $1
 	`
 
-	rows, err := t.db.Query(query, address)
+	rows, err := t.db.QueryContext(ctx, query, address)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}

--- a/repositories/task_history_repository_test.go
+++ b/repositories/task_history_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -37,7 +38,7 @@ func TestCreateTaskHistory(t *testing.T) {
 			AddRow(1, taskHistory.Address, taskHistory.TaskID, taskHistory.RewardPoints, taskHistory.Amount, taskHistory.CompletedAt, time.Now(), time.Now()))
 
 	// 呼叫 Create 函數
-	createdTaskHistory, err := repo.Create(taskHistory)
+	createdTaskHistory, err := repo.Create(context.Background(), taskHistory)
 	assert.NoError(t, err)
 	assert.NotNil(t, createdTaskHistory)
 	assert.Equal(t, taskHistory.Address, createdTaskHistory.Address)
@@ -73,7 +74,7 @@ func TestFindByID(t *testing.T) {
 			AddRow(expectedTaskHistory.ID, expectedTaskHistory.Address, expectedTaskHistory.TaskID, expectedTaskHistory.RewardPoints, expectedTaskHistory.Amount, expectedTaskHistory.CompletedAt, expectedTaskHistory.CreatedAt, expectedTaskHistory.UpdatedAt))
 
 	// 呼叫 FindByID 函數
-	result, err := repo.FindByID(taskHistoryID)
+	result, err := repo.FindByID(context.Background(), taskHistoryID)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, expectedTaskHistory.ID, result.ID)
@@ -110,7 +111,7 @@ func TestFindByAddressAndTaskId(t *testing.T) {
 			AddRow(expectedTaskHistory.ID, expectedTaskHistory.Address, expectedTaskHistory.TaskID, expectedTaskHistory.RewardPoints, expectedTaskHistory.Amount, expectedTaskHistory.CompletedAt, expectedTaskHistory.CreatedAt, expectedTaskHistory.UpdatedAt))
 
 	// 呼叫 FindByAddressAndTaskId 函數
-	result, err := repo.FindByAddressAndTaskId(address, taskId)
+	result, err := repo.FindByAddressAndTaskId(context.Background(), address, taskId)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, expectedTaskHistory.ID, result.ID)
@@ -176,7 +177,7 @@ func TestGetByAddressIncludingTasks(t *testing.T) {
 			))
 
 	// 呼叫 GetByAddressIncludingTasks 函數
-	results, err := repo.GetByAddressIncludingTasks(address)
+	results, err := repo.GetByAddressIncludingTasks(context.Background(), address)
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, expectedResults[0].TaskHistory.Address, results[0].TaskHistory.Address)

--- a/repositories/task_repository.go
+++ b/repositories/task_repository.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -9,12 +10,12 @@ import (
 )
 
 type ITaskRepository interface {
-	Create(task *entities.Task) (*entities.Task, error)
-	FindById(id int64) (*entities.Task, error)
-	FindByName(name string) (*entities.Task, error)
-	GetByName(name string) ([]*entities.Task, error)
-	IsExistedByName(name string) (bool, error)
-	GetByAddressAndNamesIncludingTaskHistories(address string, names []string) ([]*models.TaskWithTaskHistory, error)
+	Create(ctx context.Context, task *entities.Task) (*entities.Task, error)
+	FindById(ctx context.Context, id int64) (*entities.Task, error)
+	FindByName(ctx context.Context, name string) (*entities.Task, error)
+	GetByName(ctx context.Context, name string) ([]*entities.Task, error)
+	IsExistedByName(ctx context.Context, name string) (bool, error)
+	GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error)
 }
 
 type TaskRepository struct {
@@ -27,7 +28,7 @@ func NewTaskRepository(db *sql.DB) ITaskRepository {
 	}
 }
 
-func (t *TaskRepository) Create(task *entities.Task) (*entities.Task, error) {
+func (t *TaskRepository) Create(ctx context.Context, task *entities.Task) (*entities.Task, error) {
 	query := `
 		INSERT INTO tasks (name, description, points, started_at, end_at, period, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
@@ -35,7 +36,8 @@ func (t *TaskRepository) Create(task *entities.Task) (*entities.Task, error) {
 	`
 
 	var createdTask entities.Task
-	err := t.db.QueryRow(
+	err := t.db.QueryRowContext(
+		ctx,
 		query,
 		task.Name, task.Description, task.Points,
 		task.StartedAt, task.EndAt, task.Period,
@@ -52,7 +54,7 @@ func (t *TaskRepository) Create(task *entities.Task) (*entities.Task, error) {
 	return &createdTask, nil
 }
 
-func (t *TaskRepository) FindById(id int64) (*entities.Task, error) {
+func (t *TaskRepository) FindById(ctx context.Context, id int64) (*entities.Task, error) {
 	query := `
 		SELECT id, name, description, points, started_at, end_at, period, created_at, updated_at
 		FROM tasks
@@ -60,7 +62,7 @@ func (t *TaskRepository) FindById(id int64) (*entities.Task, error) {
 	`
 
 	var task entities.Task
-	err := t.db.QueryRow(query, id).Scan(
+	err := t.db.QueryRowContext(ctx, query, id).Scan(
 		&task.ID, &task.Name, &task.Description, &task.Points,
 		&task.StartedAt, &task.EndAt, &task.Period,
 		&task.CreatedAt, &task.UpdatedAt,
@@ -77,7 +79,7 @@ func (t *TaskRepository) FindById(id int64) (*entities.Task, error) {
 	return &task, nil
 }
 
-func (t *TaskRepository) FindByName(name string) (*entities.Task, error) {
+func (t *TaskRepository) FindByName(ctx context.Context, name string) (*entities.Task, error) {
 	query := `
 		SELECT id, name, description, points, started_at, end_at, period, created_at, updated_at
 		FROM tasks
@@ -85,7 +87,7 @@ func (t *TaskRepository) FindByName(name string) (*entities.Task, error) {
 	`
 
 	var task entities.Task
-	err := t.db.QueryRow(query, name).Scan(
+	err := t.db.QueryRowContext(ctx, query, name).Scan(
 		&task.ID, &task.Name, &task.Description, &task.Points,
 		&task.StartedAt, &task.EndAt, &task.Period,
 		&task.CreatedAt, &task.UpdatedAt,
@@ -102,14 +104,14 @@ func (t *TaskRepository) FindByName(name string) (*entities.Task, error) {
 	return &task, nil
 }
 
-func (t *TaskRepository) GetByName(name string) ([]*entities.Task, error) {
+func (t *TaskRepository) GetByName(ctx context.Context, name string) ([]*entities.Task, error) {
 	query := `
 		SELECT id, name, description, points, started_at, end_at, period, created_at, updated_at
 		FROM tasks
 		WHERE name = $1
 	`
 
-	rows, err := t.db.Query(query, name)
+	rows, err := t.db.QueryContext(ctx, query, name)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}
@@ -135,7 +137,7 @@ func (t *TaskRepository) GetByName(name string) ([]*entities.Task, error) {
 	return tasks, nil
 }
 
-func (t *TaskRepository) IsExistedByName(name string) (bool, error) {
+func (t *TaskRepository) IsExistedByName(ctx context.Context, name string) (bool, error) {
 	query := `
 		SELECT EXISTS (
 			SELECT 1 FROM tasks WHERE name = $1 LIMIT 1
@@ -143,7 +145,7 @@ func (t *TaskRepository) IsExistedByName(name string) (bool, error) {
 	`
 
 	var exists bool
-	err := t.db.QueryRow(query, name).Scan(&exists)
+	err := t.db.QueryRowContext(ctx, query, name).Scan(&exists)
 	if err != nil {
 		return false, fmt.Errorf("failed to check if task exists: %w", err)
 	}
@@ -151,7 +153,7 @@ func (t *TaskRepository) IsExistedByName(name string) (bool, error) {
 	return exists, nil
 }
 
-func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(address string, names []string) ([]*models.TaskWithTaskHistory, error) {
+func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error) {
 	placeholders := make([]string, len(names))
 	for i := range names {
 		placeholders[i] = fmt.Sprintf("$%d", i+2)
@@ -171,7 +173,7 @@ func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(address stri
 		args[i+1] = name
 	}
 
-	rows, err := t.db.Query(query, args...)
+	rows, err := t.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query failed: %w", err)
 	}

--- a/repositories/task_repository_test.go
+++ b/repositories/task_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"errors"
 	"regexp"
 	"testing"
@@ -43,7 +44,7 @@ func TestCreate(t *testing.T) {
 			"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
 		}).AddRow(1, task.Name, task.Description, task.Points, task.StartedAt, task.EndAt, task.Period, now, now))
 
-	createdTask, err := repo.Create(task)
+	createdTask, err := repo.Create(context.Background(), task)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, createdTask)
@@ -75,7 +76,7 @@ func TestFindById(t *testing.T) {
 			"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
 		}).AddRow(1, "Test Task", "Test Description", 10, now, now, 1, now, now))
 
-	task, err := repo.FindById(1)
+	task, err := repo.FindById(context.Background(), 1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, task)
@@ -107,7 +108,7 @@ func TestFindByName(t *testing.T) {
 			"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
 		}).AddRow(1, "Test Task", "Test Description", 10, now, now, 1, now, now))
 
-	task, err := repo.FindByName("Test Task")
+	task, err := repo.FindByName(context.Background(), "Test Task")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, task)
@@ -139,7 +140,7 @@ func TestGetByName(t *testing.T) {
 			"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
 		}).AddRow(1, "Test Task", "Test Description", 10, now, now, 1, now, now))
 
-	tasks, err := repo.GetByName("Test Task")
+	tasks, err := repo.GetByName(context.Background(), "Test Task")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tasks)
@@ -162,7 +163,7 @@ func TestIsExistedByName(t *testing.T) {
 
 		repo := &TaskRepository{db: db}
 
-		result, err := repo.IsExistedByName("test-task")
+		result, err := repo.IsExistedByName(context.Background(), "test-task")
 
 		assert.NoError(t, err)
 		assert.Equal(t, true, result)
@@ -182,7 +183,7 @@ func TestIsExistedByName(t *testing.T) {
 
 		repo := &TaskRepository{db: db}
 
-		result, err := repo.IsExistedByName("non-existent-task")
+		result, err := repo.IsExistedByName(context.Background(), "non-existent-task")
 
 		assert.NoError(t, err)
 		assert.Equal(t, false, result)
@@ -202,7 +203,7 @@ func TestIsExistedByName(t *testing.T) {
 
 		repo := &TaskRepository{db: db}
 
-		result, err := repo.IsExistedByName("error-task")
+		result, err := repo.IsExistedByName(context.Background(), "error-task")
 
 		assert.Error(t, err)
 		assert.Equal(t, false, result)
@@ -237,7 +238,7 @@ func TestGetByAddressAndNamesIncludingTaskHistoriesFiltersTasksByName(t *testing
 			nil, nil, nil, nil, nil, nil, nil,
 		))
 
-	results, err := repo.GetByAddressAndNamesIncludingTaskHistories("address1", []string{"OnboardingTask", "SharePoolTask"})
+	results, err := repo.GetByAddressAndNamesIncludingTaskHistories(context.Background(), "address1", []string{"OnboardingTask", "SharePoolTask"})
 
 	require.NoError(t, err)
 	require.Len(t, results, 1)

--- a/services/campaign_service.go
+++ b/services/campaign_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -18,13 +19,13 @@ import (
 )
 
 type ICampaignService interface {
-	StartCampaign() error
-	GetPointHistories(address string) ([]*models.TaskTaskHistoryPair, error)
-	RecordUSDCSwapTotalAmount(senderAddress string, amount float64) (float64, error)
-	GetTaskStatus(address string) ([]*models.TaskWithTaskHistory, error)
-	FindOnboardingTask() (*entities.Task, error)
-	FindCurrentSharePoolTask() (*entities.Task, error)
-	GetLeaderboard(taskName string, period int) ([]models.LeaderboardEntry, error)
+	StartCampaign(ctx context.Context) error
+	GetPointHistories(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error)
+	RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error)
+	GetTaskStatus(ctx context.Context, address string) ([]*models.TaskWithTaskHistory, error)
+	FindOnboardingTask(ctx context.Context) (*entities.Task, error)
+	FindCurrentSharePoolTask(ctx context.Context) (*entities.Task, error)
+	GetLeaderboard(ctx context.Context, taskName string, period int) ([]models.LeaderboardEntry, error)
 }
 
 type CampaignService struct {
@@ -35,6 +36,7 @@ type CampaignService struct {
 	redisHelper      helpers.IRedisHelper
 	schedulerMu      sync.Mutex
 	schedulerStarted bool
+	workerCtx        context.Context
 }
 
 const OnboardingTaskStr string = "OnboardingTask"
@@ -53,6 +55,7 @@ func NewCampaignService(
 	taskHistoryRepo repositories.ITaskHistoryRepository,
 	taskRepo repositories.ITaskRepository,
 	redisHelper helpers.IRedisHelper,
+	workerCtx context.Context,
 ) ICampaignService {
 	return &CampaignService{
 		config:          config,
@@ -60,15 +63,16 @@ func NewCampaignService(
 		taskHistoryRepo: taskHistoryRepo,
 		taskRepo:        taskRepo,
 		redisHelper:     redisHelper,
+		workerCtx:       workerCtx,
 	}
 }
 
-func (s *CampaignService) StartCampaign() error {
-	if err := s.createOnboardingTask(); err != nil {
+func (s *CampaignService) StartCampaign(ctx context.Context) error {
+	if err := s.createOnboardingTask(ctx); err != nil {
 		return err
 	}
 
-	shareTasks, err := s.createSharePoolTask()
+	shareTasks, err := s.createSharePoolTask(ctx)
 	if err != nil {
 		return err
 	}
@@ -78,33 +82,33 @@ func (s *CampaignService) StartCampaign() error {
 	return nil
 }
 
-func (s *CampaignService) GetPointHistories(address string) ([]*models.TaskTaskHistoryPair, error) {
-	return s.taskHistoryRepo.GetByAddressIncludingTasks(address)
+func (s *CampaignService) GetPointHistories(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error) {
+	return s.taskHistoryRepo.GetByAddressIncludingTasks(ctx, address)
 }
 
-func (s *CampaignService) GetTaskStatus(address string) ([]*models.TaskWithTaskHistory, error) {
-	return s.taskRepo.GetByAddressAndNamesIncludingTaskHistories(address, []string{OnboardingTaskStr, SharePoolTaskStr})
+func (s *CampaignService) GetTaskStatus(ctx context.Context, address string) ([]*models.TaskWithTaskHistory, error) {
+	return s.taskRepo.GetByAddressAndNamesIncludingTaskHistories(ctx, address, []string{OnboardingTaskStr, SharePoolTaskStr})
 }
 
-func (s *CampaignService) RecordUSDCSwapTotalAmount(senderAddress string, amount float64) (float64, error) {
+func (s *CampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error) {
 	// find current share task
-	task, err := s.FindCurrentSharePoolTask()
+	task, err := s.FindCurrentSharePoolTask(ctx)
 	if err != nil {
 		return 0, err
 	}
 
 	key := fmt.Sprintf("%s_%d", task.Name, task.Period)
-	if err := s.redisHelper.HIncrFloat(key, senderAddress, amount); err != nil {
+	if err := s.redisHelper.HIncrFloat(ctx, key, senderAddress, amount); err != nil {
 		return 0, fmt.Errorf("failed to increment address swap amount: %w", err)
 	}
 
-	totalAmountStr, err := s.redisHelper.HGet(key, senderAddress)
+	totalAmountStr, err := s.redisHelper.HGet(ctx, key, senderAddress)
 	if err != nil {
 		return 0, err
 	}
 
 	totalKey := fmt.Sprintf("%s_total", key)
-	if err := s.redisHelper.IncrFloat(totalKey, amount); err != nil {
+	if err := s.redisHelper.IncrFloat(ctx, totalKey, amount); err != nil {
 		return 0, fmt.Errorf("failed to increment total swap amount: %w", err)
 	}
 
@@ -118,13 +122,13 @@ func (s *CampaignService) RecordUSDCSwapTotalAmount(senderAddress string, amount
 		return totalAmount, nil
 	}
 
-	onboardingTask, err := s.FindOnboardingTask()
+	onboardingTask, err := s.FindOnboardingTask(ctx)
 	if err != nil {
 		return 0, err
 	}
 
 	// find existed onboarding completed task record
-	_, err = s.taskHistoryRepo.FindByAddressAndTaskId(senderAddress, onboardingTask.ID)
+	_, err = s.taskHistoryRepo.FindByAddressAndTaskId(ctx, senderAddress, onboardingTask.ID)
 	if err == nil {
 		return totalAmount, nil
 	}
@@ -139,15 +143,15 @@ func (s *CampaignService) RecordUSDCSwapTotalAmount(senderAddress string, amount
 		CompletedAt:  &now,
 	}
 
-	if _, err := s.taskHistoryRepo.Create(taskHistory); err != nil {
+	if _, err := s.taskHistoryRepo.Create(ctx, taskHistory); err != nil {
 		return 0, fmt.Errorf("failed to create onboarding task history: %w", err)
 	}
 
 	return totalAmount, nil
 }
 
-func (s *CampaignService) createOnboardingTask() error {
-	isExisted, err := s.taskRepo.IsExistedByName(OnboardingTaskStr)
+func (s *CampaignService) createOnboardingTask(ctx context.Context) error {
+	isExisted, err := s.taskRepo.IsExistedByName(ctx, OnboardingTaskStr)
 	if err != nil {
 		return err
 	}
@@ -168,15 +172,15 @@ func (s *CampaignService) createOnboardingTask() error {
 		Period:      1,
 	}
 
-	if _, err := s.taskRepo.Create(newTask); err != nil {
+	if _, err := s.taskRepo.Create(ctx, newTask); err != nil {
 		return fmt.Errorf("failed to create task: %w", err)
 	}
 
 	return nil
 }
 
-func (s *CampaignService) createSharePoolTask() ([]*entities.Task, error) {
-	tasks, err := s.taskRepo.GetByName(SharePoolTaskStr)
+func (s *CampaignService) createSharePoolTask(ctx context.Context) ([]*entities.Task, error) {
+	tasks, err := s.taskRepo.GetByName(ctx, SharePoolTaskStr)
 	if err != nil {
 		return []*entities.Task{}, err
 	}
@@ -200,7 +204,7 @@ func (s *CampaignService) createSharePoolTask() ([]*entities.Task, error) {
 			Period:      i,
 		}
 
-		task, err := s.taskRepo.Create(newTask)
+		task, err := s.taskRepo.Create(ctx, newTask)
 		if err != nil {
 			return []*entities.Task{}, fmt.Errorf("failed to create task: %w", err)
 		}
@@ -250,9 +254,9 @@ func validateSharePoolTasks(tasks []*entities.Task) ([]*entities.Task, error) {
 	return tasks, nil
 }
 
-func (s *CampaignService) FindCurrentSharePoolTask() (*entities.Task, error) {
+func (s *CampaignService) FindCurrentSharePoolTask(ctx context.Context) (*entities.Task, error) {
 	key := "curr_shared_pool_task"
-	redisData, err := s.redisHelper.Get(key)
+	redisData, err := s.redisHelper.Get(ctx, key)
 	if err == nil {
 		task := &entities.Task{}
 		json.Unmarshal([]byte(redisData), &task)
@@ -260,7 +264,7 @@ func (s *CampaignService) FindCurrentSharePoolTask() (*entities.Task, error) {
 		return task, nil
 	}
 
-	tasks, err := s.taskRepo.GetByName(SharePoolTaskStr)
+	tasks, err := s.taskRepo.GetByName(ctx, SharePoolTaskStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch share pool tasks: %w", err)
 	}
@@ -269,7 +273,7 @@ func (s *CampaignService) FindCurrentSharePoolTask() (*entities.Task, error) {
 	for _, task := range tasks {
 		if task.StartedAt != nil && task.EndAt != nil && now.After(*task.StartedAt) && now.Before(*task.EndAt) {
 			encodedTask, _ := json.Marshal(task)
-			s.redisHelper.Set(key, string(encodedTask), time.Until(*task.EndAt))
+			s.redisHelper.Set(ctx, key, string(encodedTask), time.Until(*task.EndAt))
 
 			return task, nil
 		}
@@ -278,9 +282,9 @@ func (s *CampaignService) FindCurrentSharePoolTask() (*entities.Task, error) {
 	return nil, fmt.Errorf("no active share pool task found")
 }
 
-func (s *CampaignService) FindOnboardingTask() (*entities.Task, error) {
+func (s *CampaignService) FindOnboardingTask(ctx context.Context) (*entities.Task, error) {
 	key := "onboarding_task"
-	redisData, err := s.redisHelper.Get(key)
+	redisData, err := s.redisHelper.Get(ctx, key)
 	if err == nil {
 		task := &entities.Task{}
 		json.Unmarshal([]byte(redisData), &task)
@@ -288,13 +292,13 @@ func (s *CampaignService) FindOnboardingTask() (*entities.Task, error) {
 		return task, nil
 	}
 
-	task, err := s.taskRepo.FindByName(OnboardingTaskStr)
+	task, err := s.taskRepo.FindByName(ctx, OnboardingTaskStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch onboarding task: %w", err)
 	}
 
 	encodedTask, _ := json.Marshal(task)
-	s.redisHelper.Set(key, string(encodedTask), time.Until(*task.EndAt))
+	s.redisHelper.Set(ctx, key, string(encodedTask), time.Until(*task.EndAt))
 
 	return task, nil
 }
@@ -313,25 +317,31 @@ func (s *CampaignService) startLimitedWeeklySettlementScheduler(tasks []*entitie
 	runCount := 0
 
 	go func() {
-		for range ticker.C {
-			if runCount >= maxRuns {
-				s.logger.Info("Weekly settlement scheduler reached its limit, stopping...")
-				ticker.Stop()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.workerCtx.Done():
+				s.logger.Info("Weekly settlement scheduler stopped: %v", s.workerCtx.Err())
 				return
-			}
+			case <-ticker.C:
+				if runCount >= maxRuns {
+					s.logger.Info("Weekly settlement scheduler reached its limit, stopping...")
+					return
+				}
 
-			if err := s.calculateSharePoolPoint(tasks[runCount]); err != nil {
-				s.logger.Error("Failed to perform weekly settlement: %v", err)
-			}
+				if err := s.calculateSharePoolPoint(s.workerCtx, tasks[runCount]); err != nil {
+					s.logger.Error("Failed to perform weekly settlement: %v", err)
+				}
 
-			runCount++
+				runCount++
+			}
 		}
 	}()
 
 	s.logger.Info("Limited weekly settlement scheduler started")
 }
 
-func (s *CampaignService) calculateSharePoolPoint(task *entities.Task) error {
+func (s *CampaignService) calculateSharePoolPoint(ctx context.Context, task *entities.Task) error {
 	if task.Name != SharePoolTaskStr {
 		return fmt.Errorf("task is not shard pool task")
 	}
@@ -339,7 +349,7 @@ func (s *CampaignService) calculateSharePoolPoint(task *entities.Task) error {
 	key := fmt.Sprintf("%s_%d", task.Name, task.Period)
 	totalKey := fmt.Sprintf("%s_total", key)
 
-	totalStr, err := s.redisHelper.Get(totalKey)
+	totalStr, err := s.redisHelper.Get(ctx, totalKey)
 	if err != nil {
 		return err
 	}
@@ -349,7 +359,7 @@ func (s *CampaignService) calculateSharePoolPoint(task *entities.Task) error {
 		return fmt.Errorf("failed to parse total amount from key %s: %w", totalKey, err)
 	}
 
-	swapAmountMap, err := s.redisHelper.HGetAll(key)
+	swapAmountMap, err := s.redisHelper.HGetAll(ctx, key)
 	if err != nil {
 		return err
 	}
@@ -376,21 +386,21 @@ func (s *CampaignService) calculateSharePoolPoint(task *entities.Task) error {
 			UpdatedAt:    now,
 		}
 
-		if _, err := s.taskHistoryRepo.Create(history); err != nil {
+		if _, err := s.taskHistoryRepo.Create(ctx, history); err != nil {
 			s.logger.Error("create history failed for address %s, %v", address, err)
 			continue
 		}
 
-		s.redisHelper.ZAdd(fmt.Sprintf("%s_rank", key), &redis.Z{Score: rewards, Member: address})
+		s.redisHelper.ZAdd(ctx, fmt.Sprintf("%s_rank", key), &redis.Z{Score: rewards, Member: address})
 	}
 
 	return nil
 }
 
-func (s *CampaignService) GetLeaderboard(taskName string, period int) ([]models.LeaderboardEntry, error) {
+func (s *CampaignService) GetLeaderboard(ctx context.Context, taskName string, period int) ([]models.LeaderboardEntry, error) {
 	key := fmt.Sprintf("%s_%d_rank", taskName, period)
 
-	members, scores, err := s.redisHelper.ZRevRangeWithScores(key, 0, -1)
+	members, scores, err := s.redisHelper.ZRevRangeWithScores(ctx, key, 0, -1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch leaderboard for key %s: %w", key, err)
 	}

--- a/services/campaign_service_test.go
+++ b/services/campaign_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -43,10 +44,10 @@ func TestGetPointHistories(t *testing.T) {
 	}
 
 	// 設置 mock 返回值
-	taskHistoryRepoMock.On("GetByAddressIncludingTasks", "address1").Return(taskHistoryMock, nil)
+	taskHistoryRepoMock.On("GetByAddressIncludingTasks", mock.Anything, "address1").Return(taskHistoryMock, nil)
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
-	result, err := svc.GetPointHistories("address1")
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	result, err := svc.GetPointHistories(context.Background(), "address1")
 
 	// 驗證結果
 	assert.NoError(t, err)                   // 確保沒有錯誤
@@ -76,11 +77,11 @@ func TestGetTaskStatus(t *testing.T) {
 	}
 
 	// 設置 mock 返回值
-	taskRepoMock.On("GetByAddressAndNamesIncludingTaskHistories", "address1", []string{OnboardingTaskStr, SharePoolTaskStr}).
+	taskRepoMock.On("GetByAddressAndNamesIncludingTaskHistories", mock.Anything, "address1", []string{OnboardingTaskStr, SharePoolTaskStr}).
 		Return(taskWithHistoryMock, nil)
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
-	result, err := svc.GetTaskStatus("address1")
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	result, err := svc.GetTaskStatus(context.Background(), "address1")
 
 	// 驗證結果
 	assert.NoError(t, err)                       // 確保沒有錯誤
@@ -88,6 +89,29 @@ func TestGetTaskStatus(t *testing.T) {
 	assert.Equal(t, taskWithHistoryMock, result) // 確保返回的數據正確
 
 	// 驗證 mock 方法是否被正確調用
+	taskRepoMock.AssertExpectations(t)
+}
+
+func TestGetTaskStatusPropagatesContextToRepository(t *testing.T) {
+	cfg := &config.Config{}
+	loggerMock := &mocks.MockLogger{}
+	taskHistoryRepoMock := &mocks.MockTaskHistoryRepository{}
+	taskRepoMock := &mocks.MockTaskRepository{}
+	redisHelperMock := &mocks.MockRedisHelper{}
+	ctx := context.WithValue(context.Background(), struct{}{}, "request-context")
+
+	taskRepoMock.On(
+		"GetByAddressAndNamesIncludingTaskHistories",
+		sameContext(ctx),
+		"address1",
+		[]string{OnboardingTaskStr, SharePoolTaskStr},
+	).Return([]*models.TaskWithTaskHistory{}, nil).Once()
+
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	result, err := svc.GetTaskStatus(ctx, "address1")
+
+	assert.NoError(t, err)
+	assert.Empty(t, result)
 	taskRepoMock.AssertExpectations(t)
 }
 
@@ -99,30 +123,30 @@ func TestStartCampaign(t *testing.T) {
 	redisHelperMock := &mocks.MockRedisHelper{}
 
 	// 模擬 taskRepo 的行為
-	taskRepoMock.On("IsExistedByName", OnboardingTaskStr).Return(false, nil)
-	taskRepoMock.On("Create", mock.Anything).Return(&entities.Task{}, nil)
+	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(false, nil)
+	taskRepoMock.On("Create", mock.Anything, mock.Anything).Return(&entities.Task{}, nil)
 
 	// 模擬 share pool task 的行為
-	taskRepoMock.On("GetByName", SharePoolTaskStr).Return([]*entities.Task{}, nil)
-	taskRepoMock.On("Create", mock.Anything).Return(&entities.Task{}, nil)
+	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{}, nil)
+	taskRepoMock.On("Create", mock.Anything, mock.Anything).Return(&entities.Task{}, nil)
 
 	// 模擬 logger 的行為
 	loggerMock.On("Info", mock.Anything).Return()
 
 	// 呼叫 StartCampaign 方法
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
-	err := svc.StartCampaign()
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	err := svc.StartCampaign(context.Background())
 
 	// 驗證結果
 	assert.NoError(t, err) // 確保沒有錯誤
 
 	// 驗證 createOnboardingTask 是否被調用
-	taskRepoMock.AssertCalled(t, "IsExistedByName", OnboardingTaskStr)
-	taskRepoMock.AssertCalled(t, "Create", mock.Anything)
+	taskRepoMock.AssertCalled(t, "IsExistedByName", mock.Anything, OnboardingTaskStr)
+	taskRepoMock.AssertCalled(t, "Create", mock.Anything, mock.Anything)
 
 	// 驗證 createSharePoolTask 是否被調用
-	taskRepoMock.AssertCalled(t, "GetByName", SharePoolTaskStr)
-	taskRepoMock.AssertCalled(t, "Create", mock.Anything)
+	taskRepoMock.AssertCalled(t, "GetByName", mock.Anything, SharePoolTaskStr)
+	taskRepoMock.AssertCalled(t, "Create", mock.Anything, mock.Anything)
 
 	// 驗證 logger 是否有記錄啟動計劃
 	loggerMock.AssertCalled(t, "Info", mock.Anything)
@@ -142,12 +166,12 @@ func TestStartCampaignReturnsNoErrorWhenCampaignTasksAlreadyExist(t *testing.T) 
 		{Name: SharePoolTaskStr, Period: 4},
 	}
 
-	taskRepoMock.On("IsExistedByName", OnboardingTaskStr).Return(true, nil).Once()
-	taskRepoMock.On("GetByName", SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
+	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
+	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
 	loggerMock.On("Info", mock.Anything).Return().Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
-	err := svc.StartCampaign()
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	err := svc.StartCampaign(context.Background())
 
 	assert.NoError(t, err)
 	taskRepoMock.AssertNotCalled(t, "Create", mock.Anything)
@@ -167,11 +191,11 @@ func TestStartCampaignReturnsErrorWhenExistingSharePoolTasksAreIncomplete(t *tes
 		{Name: SharePoolTaskStr, Period: 2},
 	}
 
-	taskRepoMock.On("IsExistedByName", OnboardingTaskStr).Return(true, nil).Once()
-	taskRepoMock.On("GetByName", SharePoolTaskStr).Return(incompleteSharePoolTasks, nil).Once()
+	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
+	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(incompleteSharePoolTasks, nil).Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
-	err := svc.StartCampaign()
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	err := svc.StartCampaign(context.Background())
 
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "expected 4 share pool tasks")
@@ -194,18 +218,18 @@ func TestStartCampaignDoesNotStartDuplicateScheduler(t *testing.T) {
 		{Name: SharePoolTaskStr, Period: 4},
 	}
 
-	taskRepoMock.On("IsExistedByName", OnboardingTaskStr).Return(false, nil).Once()
-	taskRepoMock.On("Create", mock.Anything).Return(&entities.Task{}, nil).Times(5)
-	taskRepoMock.On("GetByName", SharePoolTaskStr).Return([]*entities.Task{}, nil).Once()
+	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(false, nil).Once()
+	taskRepoMock.On("Create", mock.Anything, mock.Anything).Return(&entities.Task{}, nil).Times(5)
+	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{}, nil).Once()
 	loggerMock.On("Info", mock.Anything).Return().Once()
 
-	taskRepoMock.On("IsExistedByName", OnboardingTaskStr).Return(true, nil).Once()
-	taskRepoMock.On("GetByName", SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
+	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
+	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
 
-	assert.NoError(t, svc.StartCampaign())
-	assert.NoError(t, svc.StartCampaign())
+	assert.NoError(t, svc.StartCampaign(context.Background()))
+	assert.NoError(t, svc.StartCampaign(context.Background()))
 
 	taskRepoMock.AssertNumberOfCalls(t, "Create", 5)
 	loggerMock.AssertNumberOfCalls(t, "Info", 1)
@@ -225,9 +249,9 @@ func TestFindCurrentSharePoolTask(t *testing.T) {
 	}
 
 	// 測試場景：Redis 已經有資料
-	mockRedisHelper.On("Get", "curr_shared_pool_task").Return(`{"id":1,"name":"share_pool","started_at":"2024-11-01T00:00:00Z","end_at":"2024-11-30T00:00:00Z"}`, nil)
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return(`{"id":1,"name":"share_pool","started_at":"2024-11-01T00:00:00Z","end_at":"2024-11-30T00:00:00Z"}`, nil)
 
-	task, err := service.FindCurrentSharePoolTask()
+	task, err := service.FindCurrentSharePoolTask(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, "share_pool", task.Name)
@@ -247,9 +271,9 @@ func TestFindOnboardingTask(t *testing.T) {
 	}
 
 	// 測試場景：Redis 已經有資料
-	mockRedisHelper.On("Get", "onboarding_task").Return(`{"id":1,"name":"onboarding","started_at":"2024-11-01T00:00:00Z","end_at":"2024-11-30T00:00:00Z"}`, nil)
+	mockRedisHelper.On("Get", mock.Anything, "onboarding_task").Return(`{"id":1,"name":"onboarding","started_at":"2024-11-01T00:00:00Z","end_at":"2024-11-30T00:00:00Z"}`, nil)
 
-	task, err := service.FindOnboardingTask()
+	task, err := service.FindOnboardingTask(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, "onboarding", task.Name)
@@ -284,23 +308,23 @@ func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 	totalAmountStr := "100.0"
 
 	// Mock Redis responses
-	mockRedisHelper.On("HIncrFloat", mock.Anything, senderAddress, amount).Return(nil)
-	mockRedisHelper.On("HGet", mock.Anything, senderAddress).Return(totalAmountStr, nil)
-	mockRedisHelper.On("IncrFloat", mock.Anything, amount).Return(nil)
-	mockRedisHelper.On("Get", mock.Anything).Return(totalAmountStr, nil)
+	mockRedisHelper.On("HIncrFloat", mock.Anything, mock.Anything, senderAddress, amount).Return(nil)
+	mockRedisHelper.On("HGet", mock.Anything, mock.Anything, senderAddress).Return(totalAmountStr, nil)
+	mockRedisHelper.On("IncrFloat", mock.Anything, mock.Anything, amount).Return(nil)
+	mockRedisHelper.On("Get", mock.Anything, mock.Anything).Return(totalAmountStr, nil)
 
 	// Mock FindCurrentSharePoolTask response
-	mockTaskRepo.On("GetByName", "share_pool_task").Return([]*entities.Task{currentTask}, nil)
-	mockTaskRepo.On("FindByName", "onboarding_task").Return(onboardingTask, nil)
+	mockTaskRepo.On("GetByName", mock.Anything, "share_pool_task").Return([]*entities.Task{currentTask}, nil)
+	mockTaskRepo.On("FindByName", mock.Anything, "onboarding_task").Return(onboardingTask, nil)
 
 	// Mock task history repo to simulate no existing onboarding task history
-	mockTaskHistoryRepo.On("FindByAddressAndTaskId", senderAddress, onboardingTask.ID).Return(nil, errors.New("not found"))
+	mockTaskHistoryRepo.On("FindByAddressAndTaskId", mock.Anything, senderAddress, onboardingTask.ID).Return(nil, errors.New("not found"))
 
 	// Simulate successful creation of task history
-	mockTaskHistoryRepo.On("Create", mock.Anything).Return(nil)
+	mockTaskHistoryRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
 
 	// Call the method under test
-	totalAmountReturned, err := campaignService.RecordUSDCSwapTotalAmount(senderAddress, amount)
+	totalAmountReturned, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), senderAddress, amount)
 
 	// Assert the results
 	assert.NoError(t, err)
@@ -329,16 +353,52 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenUserAmountIncrementFails(t *te
 	}
 	key := "SharePoolTask_1"
 
-	mockRedisHelper.On("Get", "curr_shared_pool_task").Return("", errors.New("cache miss"))
-	mockTaskRepo.On("GetByName", SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
-	mockRedisHelper.On("Set", "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", key, "0x123", 100.0).Return(errors.New("redis hincr failed"))
-	mockRedisHelper.On("HGet", key, "0x123").Return("100", nil).Maybe()
-	mockRedisHelper.On("IncrFloat", key+"_total", 100.0).Return(nil).Maybe()
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
+	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 100.0).Return(errors.New("redis hincr failed"))
+	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("100", nil).Maybe()
+	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 100.0).Return(nil).Maybe()
 
-	_, err := campaignService.RecordUSDCSwapTotalAmount("0x123", 100.0)
+	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 100.0)
 
 	assert.ErrorContains(t, err, "redis hincr failed")
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertExpectations(t)
+}
+
+func TestRecordUSDCSwapTotalAmountPropagatesContextToDependencies(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
+	ctx := context.WithValue(context.Background(), struct{}{}, "record-context")
+	campaignService := &CampaignService{
+		redisHelper:     mockRedisHelper,
+		taskRepo:        mockTaskRepo,
+		taskHistoryRepo: mockTaskHistoryRepo,
+		workerCtx:       context.Background(),
+	}
+
+	now := time.Now()
+	currentTask := &entities.Task{
+		Name:      SharePoolTaskStr,
+		Period:    1,
+		StartedAt: &now,
+		EndAt:     ptrTime(now.Add(time.Hour)),
+	}
+	key := "SharePoolTask_1"
+
+	mockRedisHelper.On("Get", sameContext(ctx), "curr_shared_pool_task").Return("", errors.New("cache miss")).Once()
+	mockTaskRepo.On("GetByName", sameContext(ctx), SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil).Once()
+	mockRedisHelper.On("Set", sameContext(ctx), "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil).Once()
+	mockRedisHelper.On("HIncrFloat", sameContext(ctx), key, "0x123", 100.0).Return(nil).Once()
+	mockRedisHelper.On("HGet", sameContext(ctx), key, "0x123").Return("100", nil).Once()
+	mockRedisHelper.On("IncrFloat", sameContext(ctx), key+"_total", 100.0).Return(nil).Once()
+
+	totalAmount, err := campaignService.RecordUSDCSwapTotalAmount(ctx, "0x123", 100.0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, totalAmount)
 	mockRedisHelper.AssertExpectations(t)
 	mockTaskRepo.AssertExpectations(t)
 }
@@ -362,14 +422,14 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenTotalAmountIncrementFails(t *t
 	}
 	key := "SharePoolTask_1"
 
-	mockRedisHelper.On("Get", "curr_shared_pool_task").Return("", errors.New("cache miss"))
-	mockTaskRepo.On("GetByName", SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
-	mockRedisHelper.On("Set", "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", key, "0x123", 100.0).Return(nil)
-	mockRedisHelper.On("HGet", key, "0x123").Return("100", nil)
-	mockRedisHelper.On("IncrFloat", key+"_total", 100.0).Return(errors.New("redis incr failed"))
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
+	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 100.0).Return(nil)
+	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("100", nil)
+	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 100.0).Return(errors.New("redis incr failed"))
 
-	_, err := campaignService.RecordUSDCSwapTotalAmount("0x123", 100.0)
+	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 100.0)
 
 	assert.ErrorContains(t, err, "redis incr failed")
 	mockRedisHelper.AssertExpectations(t)
@@ -400,19 +460,19 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenOnboardingHistoryCreateFails(t
 	}
 	key := "SharePoolTask_1"
 
-	mockRedisHelper.On("Get", "curr_shared_pool_task").Return("", errors.New("cache miss"))
-	mockTaskRepo.On("GetByName", SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
-	mockRedisHelper.On("Set", "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", key, "0x123", 1000.0).Return(nil)
-	mockRedisHelper.On("HGet", key, "0x123").Return("1000", nil)
-	mockRedisHelper.On("IncrFloat", key+"_total", 1000.0).Return(nil)
-	mockRedisHelper.On("Get", "onboarding_task").Return("", errors.New("cache miss"))
-	mockTaskRepo.On("FindByName", OnboardingTaskStr).Return(onboardingTask, nil)
-	mockRedisHelper.On("Set", "onboarding_task", mock.Anything, mock.Anything).Return(nil)
-	mockTaskHistoryRepo.On("FindByAddressAndTaskId", "0x123", onboardingTask.ID).Return(nil, errors.New("not found"))
-	mockTaskHistoryRepo.On("Create", mock.Anything).Return(&entities.TaskHistory{}, errors.New("db create failed"))
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
+	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 1000.0).Return(nil)
+	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("1000", nil)
+	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 1000.0).Return(nil)
+	mockRedisHelper.On("Get", mock.Anything, "onboarding_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("FindByName", mock.Anything, OnboardingTaskStr).Return(onboardingTask, nil)
+	mockRedisHelper.On("Set", mock.Anything, "onboarding_task", mock.Anything, mock.Anything).Return(nil)
+	mockTaskHistoryRepo.On("FindByAddressAndTaskId", mock.Anything, "0x123", onboardingTask.ID).Return(nil, errors.New("not found"))
+	mockTaskHistoryRepo.On("Create", mock.Anything, mock.Anything).Return(&entities.TaskHistory{}, errors.New("db create failed"))
 
-	_, err := campaignService.RecordUSDCSwapTotalAmount("0x123", 1000.0)
+	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 1000.0)
 
 	assert.ErrorContains(t, err, "db create failed")
 	mockRedisHelper.AssertExpectations(t)
@@ -422,6 +482,12 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenOnboardingHistoryCreateFails(t
 
 func ptrTime(t time.Time) *time.Time {
 	return &t
+}
+
+func sameContext(expected context.Context) interface{} {
+	return mock.MatchedBy(func(actual context.Context) bool {
+		return actual == expected
+	})
 }
 
 func TestCampaignService_GetLeaderboard(t *testing.T) {
@@ -442,7 +508,7 @@ func TestCampaignService_GetLeaderboard(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		// Mock Redis response
-		mockRedisHelper.On("ZRevRangeWithScores", key, int64(0), int64(-1)).
+		mockRedisHelper.On("ZRevRangeWithScores", mock.Anything, key, int64(0), int64(-1)).
 			Return([]string{"address1", "address2"}, []float64{100.5, 75.3}, nil)
 
 		// Expected result
@@ -452,7 +518,7 @@ func TestCampaignService_GetLeaderboard(t *testing.T) {
 		}
 
 		// Call the method
-		result, err := campaignService.GetLeaderboard(taskName, period)
+		result, err := campaignService.GetLeaderboard(context.Background(), taskName, period)
 
 		// Assertions
 		assert.NoError(t, err)

--- a/services/ethereum_service.go
+++ b/services/ethereum_service.go
@@ -24,7 +24,7 @@ type IEthereumClient interface {
 }
 
 type IEthereumService interface {
-	SubscribeEthereumSwap() error
+	SubscribeEthereumSwap(ctx context.Context) error
 }
 
 type IABI interface {
@@ -48,8 +48,8 @@ func NewEthereumService(logger logger.ILogger, config *config.Config, campaignSe
 	}
 }
 
-func (e *EthereumService) SubscribeEthereumSwap() error {
-	client, err := e.connectToClient()
+func (e *EthereumService) SubscribeEthereumSwap(ctx context.Context) error {
+	client, err := e.connectToClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -59,32 +59,41 @@ func (e *EthereumService) SubscribeEthereumSwap() error {
 		return err
 	}
 
-	logsCh, sub, err := e.subscribeToSwapEvent(client)
+	logsCh, sub, err := e.subscribeToSwapEvent(ctx, client)
 	if err != nil {
 		return err
 	}
 
 	defer sub.Unsubscribe()
 
-	for vLog := range logsCh {
-		event, err := e.retrieveEventData(vLog, parsedABI)
-		if err != nil {
-			e.logger.Error(err)
-			continue
-		}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-sub.Err():
+			return fmt.Errorf("ethereum subscription error: %w", err)
+		case vLog, ok := <-logsCh:
+			if !ok {
+				return nil
+			}
 
-		err = e.processSwapEvent(event)
-		if err != nil {
-			e.logger.Error(err)
+			event, err := e.retrieveEventData(vLog, parsedABI)
+			if err != nil {
+				e.logger.Error(err)
+				continue
+			}
+
+			err = e.processSwapEvent(ctx, event)
+			if err != nil {
+				e.logger.Error(err)
+			}
 		}
 	}
-
-	return nil
 }
 
-func (e *EthereumService) connectToClient() (*ethclient.Client, error) {
+func (e *EthereumService) connectToClient(ctx context.Context) (*ethclient.Client, error) {
 	url := fmt.Sprintf("wss://mainnet.infura.io/ws/v3/%s", e.config.Infura.Key)
-	client, err := ethclient.Dial(url)
+	client, err := ethclient.DialContext(ctx, url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to Ethereum client: %v", err)
 	}
@@ -149,7 +158,7 @@ func (e *EthereumService) parseABI() (abi.ABI, error) {
 	return parsedABI, nil
 }
 
-func (e *EthereumService) subscribeToSwapEvent(client IEthereumClient) (<-chan types.Log, ethereum.Subscription, error) {
+func (e *EthereumService) subscribeToSwapEvent(ctx context.Context, client IEthereumClient) (<-chan types.Log, ethereum.Subscription, error) {
 	contractAddressHex := "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc"
 	contractAddress := common.HexToAddress(contractAddressHex)
 	eventSignature := "Swap(address,uint256,uint256,uint256,uint256,address)"
@@ -161,7 +170,7 @@ func (e *EthereumService) subscribeToSwapEvent(client IEthereumClient) (<-chan t
 	}
 
 	logsCh := make(chan types.Log)
-	sub, err := client.SubscribeFilterLogs(context.Background(), query, logsCh)
+	sub, err := client.SubscribeFilterLogs(ctx, query, logsCh)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to subscribe: %v", err)
 	}
@@ -182,7 +191,7 @@ func (e *EthereumService) retrieveEventData(vLog types.Log, parsedABI IABI) (*mo
 	return &event, nil
 }
 
-func (e *EthereumService) processSwapEvent(event *models.SwapEvent) error {
+func (e *EthereumService) processSwapEvent(ctx context.Context, event *models.SwapEvent) error {
 	senderAddress := event.SenderAddress
 	e.logger.Info("Sender: %s", senderAddress)
 
@@ -213,13 +222,13 @@ func (e *EthereumService) processSwapEvent(event *models.SwapEvent) error {
 
 	go func() {
 		defer wg.Done()
-		_, err := e.campaignService.RecordUSDCSwapTotalAmount(event.SenderAddress, amountInUSDCFloat64)
+		_, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, event.SenderAddress, amountInUSDCFloat64)
 		errCh <- err
 	}()
 
 	go func() {
 		defer wg.Done()
-		_, err := e.campaignService.RecordUSDCSwapTotalAmount(event.SenderAddress, amountOutUSDCFloat64)
+		_, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, event.SenderAddress, amountOutUSDCFloat64)
 		errCh <- err
 	}()
 

--- a/services/ethereum_service_test.go
+++ b/services/ethereum_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -39,7 +40,7 @@ func TestSubscribeToSwapEvent(t *testing.T) {
 	e := &EthereumService{}
 
 	// 呼叫 subscribeToSwapEvent 方法
-	logsCh, sub, err := e.subscribeToSwapEvent(mockClient)
+	logsCh, sub, err := e.subscribeToSwapEvent(context.Background(), mockClient)
 
 	// 驗證結果
 	assert.NoError(t, err, "expected no error")
@@ -47,6 +48,25 @@ func TestSubscribeToSwapEvent(t *testing.T) {
 	assert.NotNil(t, sub, "expected subscription to be returned")
 
 	// 驗證 Mock 方法被正確呼叫
+	mockClient.AssertExpectations(t)
+}
+
+func TestSubscribeToSwapEventUsesProvidedContext(t *testing.T) {
+	mockClient := new(mocks.MockEthereumClient)
+	mockSubscription := new(mocks.MockEthereumSubscription)
+	ctx := context.WithValue(context.Background(), struct{}{}, "ethereum-listener")
+
+	mockClient.On("SubscribeFilterLogs", mock.MatchedBy(func(actual context.Context) bool {
+		return actual == ctx
+	}), mock.Anything, mock.Anything).Return(mockSubscription, nil).Once()
+
+	e := &EthereumService{}
+
+	logsCh, sub, err := e.subscribeToSwapEvent(ctx, mockClient)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, logsCh)
+	assert.NotNil(t, sub)
 	mockClient.AssertExpectations(t)
 }
 
@@ -102,7 +122,7 @@ func TestProcessSwapEvent(t *testing.T) {
 	mockLogger.On("Info", mock.Anything).Return()
 
 	// Mock RecordUSDCSwapTotalAmount behavior
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", "0xSenderAddress", mock.Anything).Return(100.0, nil)
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything).Return(100.0, nil)
 
 	// Create EthereumService instance
 	e := &EthereumService{
@@ -119,7 +139,7 @@ func TestProcessSwapEvent(t *testing.T) {
 	}
 
 	// Test processSwapEvent
-	err := e.processSwapEvent(event)
+	err := e.processSwapEvent(context.Background(), event)
 	assert.NoError(t, err, "expected no error")
 
 	// Verify expectations
@@ -127,7 +147,7 @@ func TestProcessSwapEvent(t *testing.T) {
 	mockCampaignService.AssertExpectations(t)
 
 	// Additional assertions for verifying specific behaviors
-	mockCampaignService.AssertCalled(t, "RecordUSDCSwapTotalAmount", "0xSenderAddress", mock.Anything)
+	mockCampaignService.AssertCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything)
 }
 
 func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
@@ -135,7 +155,7 @@ func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 	mockCampaignService := new(mocks.MockCampaignService)
 
 	mockLogger.On("Info", mock.Anything).Return()
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", "0xSenderAddress", mock.Anything).
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything).
 		Return(0.0, fmt.Errorf("record failed"))
 
 	e := &EthereumService{
@@ -151,7 +171,7 @@ func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 		Amount1Out:    big.NewInt(10),
 	}
 
-	err := e.processSwapEvent(event)
+	err := e.processSwapEvent(context.Background(), event)
 
 	assert.ErrorContains(t, err, "record failed")
 	mockLogger.AssertExpectations(t)


### PR DESCRIPTION
## Summary
- Add configurable Gin timeout middleware using `server.request_timeout_seconds`, defaulting invalid or missing values to 10 seconds.
- Propagate `context.Context` from HTTP controllers through services, repositories, Redis helper, and Ethereum event processing.
- Move Ethereum subscription and HTTP server startup/shutdown onto Fx lifecycle hooks, with background worker context tied to app lifecycle.
- Add tests for timeout middleware/config, exact context propagation, lifecycle cancellation, and updated repository/Redis/service APIs.

## Verification
- `go test ./... -count=1`
- `go build ./...`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `git diff --check`
