### PR TITLE
Fix swap participant attribution and reward accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is positioned as a portfolio prototype. It focuses on showing th
 ```text
 Uniswap USDC/WETH Swap event
   -> Ethereum listener
+  -> Transaction sender lookup
   -> USDC amount extraction
   -> Campaign service
   -> Redis volume accumulation
@@ -168,6 +169,7 @@ Not production-ready yet:
 
 - Event listener reconnect/backoff behavior.
 - Historical backfill and event deduplication.
+- Participant attribution uses transaction sender (`tx.from`); aggregators and smart contract wallets may require deeper trace-based attribution.
 - Durable settlement worker state.
 - Multi-instance locking for reward settlement.
 - Automated database migrations during container startup.

--- a/mocks/ethereum_client.go
+++ b/mocks/ethereum_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/mock"
 )
@@ -15,4 +16,15 @@ type MockEthereumClient struct {
 func (m *MockEthereumClient) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, logsCh chan<- types.Log) (ethereum.Subscription, error) {
 	args := m.Called(ctx, query, logsCh)
 	return args.Get(0).(ethereum.Subscription), args.Error(1)
+}
+
+func (m *MockEthereumClient) TransactionByHash(ctx context.Context, hash common.Hash) (*types.Transaction, bool, error) {
+	args := m.Called(ctx, hash)
+
+	var tx *types.Transaction
+	if args.Get(0) != nil {
+		tx = args.Get(0).(*types.Transaction)
+	}
+
+	return tx, args.Bool(1), args.Error(2)
 }

--- a/models/swap_event.go
+++ b/models/swap_event.go
@@ -1,9 +1,14 @@
 package models
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 type SwapEvent struct {
 	SenderAddress string
+	TxHash        common.Hash
 	Amount0In     *big.Int
 	Amount1In     *big.Int
 	Amount0Out    *big.Int

--- a/repositories/task_repository.go
+++ b/repositories/task_repository.go
@@ -134,6 +134,10 @@ func (t *TaskRepository) GetByName(ctx context.Context, name string) ([]*entitie
 		tasks = append(tasks, task)
 	}
 
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration failed: %w", err)
+	}
+
 	return tasks, nil
 }
 
@@ -154,6 +158,10 @@ func (t *TaskRepository) IsExistedByName(ctx context.Context, name string) (bool
 }
 
 func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error) {
+	if len(names) == 0 {
+		return nil, fmt.Errorf("task names cannot be empty")
+	}
+
 	placeholders := make([]string, len(names))
 	for i := range names {
 		placeholders[i] = fmt.Sprintf("$%d", i+2)
@@ -165,6 +173,7 @@ func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.
 		FROM tasks t
 		LEFT JOIN task_histories th ON t.id = th.task_id AND th.address = $1
 		WHERE t.name IN (%s)
+		ORDER BY t.name, t.period
 	`, strings.Join(placeholders, ","))
 
 	args := make([]interface{}, len(names)+1)
@@ -197,6 +206,10 @@ func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.
 		}
 
 		results = append(results, taskWithHistory)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("row iteration failed: %w", err)
 	}
 
 	return results, nil

--- a/repositories/task_repository_test.go
+++ b/repositories/task_repository_test.go
@@ -150,6 +150,34 @@ func TestGetByName(t *testing.T) {
 	}
 }
 
+func TestGetByNameReturnsRowsError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	now := time.Now()
+
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
+	}).AddRow(1, "Test Task", "Test Description", 10, now, now, 1, now, now).
+		RowError(0, errors.New("row iteration failed"))
+
+	mock.ExpectQuery(`
+		SELECT id, name, description, points, started_at, end_at, period, created_at, updated_at
+		FROM tasks
+		WHERE name = \$1
+	`).
+		WithArgs("Test Task").
+		WillReturnRows(rows)
+
+	tasks, err := repo.GetByName(context.Background(), "Test Task")
+
+	assert.Nil(t, tasks)
+	assert.ErrorContains(t, err, "row iteration failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestIsExistedByName(t *testing.T) {
 	// 測試場景：Task exists
 	t.Run("Task exists", func(t *testing.T) {
@@ -226,6 +254,7 @@ func TestGetByAddressAndNamesIncludingTaskHistoriesFiltersTasksByName(t *testing
 		FROM tasks t
 		LEFT JOIN task_histories th ON t.id = th.task_id AND th.address = $1
 		WHERE t.name IN ($2,$3)
+		ORDER BY t.name, t.period
 	`)
 
 	mock.ExpectQuery(queryPattern).
@@ -244,4 +273,53 @@ func TestGetByAddressAndNamesIncludingTaskHistoriesFiltersTasksByName(t *testing
 	require.Len(t, results, 1)
 	assert.Equal(t, "OnboardingTask", results[0].TaskName)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetByAddressAndNamesIncludingTaskHistoriesReturnsRowsError(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	now := time.Now()
+
+	queryPattern := regexp.QuoteMeta(`
+		SELECT t.id, t.name, t.description, t.points, t.started_at, t.end_at, t.period, t.created_at, t.updated_at,
+			th.id, th.address, th.reward_points, th.amount, th.completed_at, th.created_at, th.updated_at
+		FROM tasks t
+		LEFT JOIN task_histories th ON t.id = th.task_id AND th.address = $1
+		WHERE t.name IN ($2)
+		ORDER BY t.name, t.period
+	`)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
+		"id", "address", "reward_points", "amount", "completed_at", "created_at", "updated_at",
+	}).AddRow(
+		1, "OnboardingTask", "Onboarding", 100, now, now, 1, now, now,
+		nil, nil, nil, nil, nil, nil, nil,
+	).RowError(0, errors.New("row iteration failed"))
+
+	mock.ExpectQuery(queryPattern).
+		WithArgs("address1", "OnboardingTask").
+		WillReturnRows(rows)
+
+	results, err := repo.GetByAddressAndNamesIncludingTaskHistories(context.Background(), "address1", []string{"OnboardingTask"})
+
+	assert.Nil(t, results)
+	assert.ErrorContains(t, err, "row iteration failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetByAddressAndNamesIncludingTaskHistoriesReturnsErrorForEmptyNames(t *testing.T) {
+	db, _, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+
+	results, err := repo.GetByAddressAndNamesIncludingTaskHistories(context.Background(), "address1", nil)
+
+	assert.Nil(t, results)
+	assert.ErrorContains(t, err, "task names cannot be empty")
 }

--- a/services/campaign_service.go
+++ b/services/campaign_service.go
@@ -258,10 +258,7 @@ func (s *CampaignService) FindCurrentSharePoolTask(ctx context.Context) (*entiti
 	key := "curr_shared_pool_task"
 	redisData, err := s.redisHelper.Get(ctx, key)
 	if err == nil {
-		task := &entities.Task{}
-		json.Unmarshal([]byte(redisData), &task)
-
-		return task, nil
+		return decodeCachedTask(redisData, "current share pool task")
 	}
 
 	tasks, err := s.taskRepo.GetByName(ctx, SharePoolTaskStr)
@@ -272,8 +269,9 @@ func (s *CampaignService) FindCurrentSharePoolTask(ctx context.Context) (*entiti
 	now := time.Now().UTC()
 	for _, task := range tasks {
 		if task.StartedAt != nil && task.EndAt != nil && now.After(*task.StartedAt) && now.Before(*task.EndAt) {
-			encodedTask, _ := json.Marshal(task)
-			s.redisHelper.Set(ctx, key, string(encodedTask), time.Until(*task.EndAt))
+			if err := s.cacheTask(ctx, key, task, "current share pool task"); err != nil {
+				return nil, err
+			}
 
 			return task, nil
 		}
@@ -286,10 +284,7 @@ func (s *CampaignService) FindOnboardingTask(ctx context.Context) (*entities.Tas
 	key := "onboarding_task"
 	redisData, err := s.redisHelper.Get(ctx, key)
 	if err == nil {
-		task := &entities.Task{}
-		json.Unmarshal([]byte(redisData), &task)
-
-		return task, nil
+		return decodeCachedTask(redisData, "onboarding task")
 	}
 
 	task, err := s.taskRepo.FindByName(ctx, OnboardingTaskStr)
@@ -297,10 +292,45 @@ func (s *CampaignService) FindOnboardingTask(ctx context.Context) (*entities.Tas
 		return nil, fmt.Errorf("failed to fetch onboarding task: %w", err)
 	}
 
-	encodedTask, _ := json.Marshal(task)
-	s.redisHelper.Set(ctx, key, string(encodedTask), time.Until(*task.EndAt))
+	if err := s.cacheTask(ctx, key, task, "onboarding task"); err != nil {
+		return nil, err
+	}
 
 	return task, nil
+}
+
+func decodeCachedTask(redisData string, label string) (*entities.Task, error) {
+	task := &entities.Task{}
+	if err := json.Unmarshal([]byte(redisData), task); err != nil {
+		return nil, fmt.Errorf("failed to decode %s cache: %w", label, err)
+	}
+
+	if task.Name == "" {
+		return nil, fmt.Errorf("failed to decode %s cache: task name is empty", label)
+	}
+
+	return task, nil
+}
+
+func (s *CampaignService) cacheTask(ctx context.Context, key string, task *entities.Task, label string) error {
+	if task == nil {
+		return fmt.Errorf("failed to cache %s: task is nil", label)
+	}
+
+	if task.EndAt == nil {
+		return fmt.Errorf("failed to cache %s: task end time is missing", label)
+	}
+
+	encodedTask, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("failed to encode %s cache: %w", label, err)
+	}
+
+	if err := s.redisHelper.Set(ctx, key, string(encodedTask), time.Until(*task.EndAt)); err != nil {
+		return fmt.Errorf("failed to cache %s: %w", label, err)
+	}
+
+	return nil
 }
 
 func (s *CampaignService) startLimitedWeeklySettlementScheduler(tasks []*entities.Task) {

--- a/services/campaign_service_test.go
+++ b/services/campaign_service_test.go
@@ -259,6 +259,52 @@ func TestFindCurrentSharePoolTask(t *testing.T) {
 	mockTaskRepo.AssertExpectations(t)
 }
 
+func TestFindCurrentSharePoolTaskReturnsErrorWhenCachedTaskCannotDecode(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	service := &CampaignService{
+		redisHelper: mockRedisHelper,
+		taskRepo:    mockTaskRepo,
+	}
+
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return(`{bad json`, nil)
+
+	task, err := service.FindCurrentSharePoolTask(context.Background())
+
+	assert.Nil(t, task)
+	assert.ErrorContains(t, err, "failed to decode current share pool task cache")
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertNotCalled(t, "GetByName", mock.Anything, mock.Anything)
+}
+
+func TestFindCurrentSharePoolTaskReturnsErrorWhenCachingActiveTaskFails(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	now := time.Now()
+	activeTask := &entities.Task{
+		ID:        1,
+		Name:      SharePoolTaskStr,
+		StartedAt: ptrTime(now.Add(-time.Hour)),
+		EndAt:     ptrTime(now.Add(time.Hour)),
+		Period:    1,
+	}
+	service := &CampaignService{
+		redisHelper: mockRedisHelper,
+		taskRepo:    mockTaskRepo,
+	}
+
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{activeTask}, nil)
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(errors.New("redis set failed"))
+
+	task, err := service.FindCurrentSharePoolTask(context.Background())
+
+	assert.Nil(t, task)
+	assert.ErrorContains(t, err, "failed to cache current share pool task")
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertExpectations(t)
+}
+
 func TestFindOnboardingTask(t *testing.T) {
 	// 設置模擬的 RedisHelper 和 TaskRepo
 	mockRedisHelper := new(mocks.MockRedisHelper)
@@ -281,6 +327,50 @@ func TestFindOnboardingTask(t *testing.T) {
 	mockTaskRepo.AssertExpectations(t)
 }
 
+func TestFindOnboardingTaskReturnsErrorWhenCachedTaskCannotDecode(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	service := &CampaignService{
+		redisHelper: mockRedisHelper,
+		taskRepo:    mockTaskRepo,
+	}
+
+	mockRedisHelper.On("Get", mock.Anything, "onboarding_task").Return(`{bad json`, nil)
+
+	task, err := service.FindOnboardingTask(context.Background())
+
+	assert.Nil(t, task)
+	assert.ErrorContains(t, err, "failed to decode onboarding task cache")
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertNotCalled(t, "FindByName", mock.Anything, mock.Anything)
+}
+
+func TestFindOnboardingTaskReturnsErrorWhenCachingTaskFails(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	now := time.Now()
+	task := &entities.Task{
+		ID:    1,
+		Name:  OnboardingTaskStr,
+		EndAt: ptrTime(now.Add(time.Hour)),
+	}
+	service := &CampaignService{
+		redisHelper: mockRedisHelper,
+		taskRepo:    mockTaskRepo,
+	}
+
+	mockRedisHelper.On("Get", mock.Anything, "onboarding_task").Return("", errors.New("cache miss"))
+	mockTaskRepo.On("FindByName", mock.Anything, OnboardingTaskStr).Return(task, nil)
+	mockRedisHelper.On("Set", mock.Anything, "onboarding_task", mock.Anything, mock.Anything).Return(errors.New("redis set failed"))
+
+	result, err := service.FindOnboardingTask(context.Background())
+
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "failed to cache onboarding task")
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertExpectations(t)
+}
+
 func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 	// Mock dependencies
 	mockRedisHelper := new(mocks.MockRedisHelper)
@@ -296,32 +386,25 @@ func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 	// Mock data
 	senderAddress := "0x123"
 	amount := 100.0
+	now := time.Now()
 	currentTask := &entities.Task{
-		Name:   "share_pool_task",
-		Period: 1,
-	}
-	onboardingTask := &entities.Task{
-		ID:     1,
-		Name:   "onboarding_task",
-		Period: 1,
+		Name:      SharePoolTaskStr,
+		StartedAt: ptrTime(now.Add(-time.Hour)),
+		EndAt:     ptrTime(now.Add(time.Hour)),
+		Period:    1,
 	}
 	totalAmountStr := "100.0"
+	key := "SharePoolTask_1"
 
 	// Mock Redis responses
-	mockRedisHelper.On("HIncrFloat", mock.Anything, mock.Anything, senderAddress, amount).Return(nil)
-	mockRedisHelper.On("HGet", mock.Anything, mock.Anything, senderAddress).Return(totalAmountStr, nil)
-	mockRedisHelper.On("IncrFloat", mock.Anything, mock.Anything, amount).Return(nil)
-	mockRedisHelper.On("Get", mock.Anything, mock.Anything).Return(totalAmountStr, nil)
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
+	mockRedisHelper.On("HIncrFloat", mock.Anything, key, senderAddress, amount).Return(nil)
+	mockRedisHelper.On("HGet", mock.Anything, key, senderAddress).Return(totalAmountStr, nil)
+	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", amount).Return(nil)
 
 	// Mock FindCurrentSharePoolTask response
-	mockTaskRepo.On("GetByName", mock.Anything, "share_pool_task").Return([]*entities.Task{currentTask}, nil)
-	mockTaskRepo.On("FindByName", mock.Anything, "onboarding_task").Return(onboardingTask, nil)
-
-	// Mock task history repo to simulate no existing onboarding task history
-	mockTaskHistoryRepo.On("FindByAddressAndTaskId", mock.Anything, senderAddress, onboardingTask.ID).Return(nil, errors.New("not found"))
-
-	// Simulate successful creation of task history
-	mockTaskHistoryRepo.On("Create", mock.Anything, mock.Anything).Return(nil)
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
 
 	// Call the method under test
 	totalAmountReturned, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), senderAddress, amount)
@@ -332,6 +415,8 @@ func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 
 	// Assert that the Redis helper and task history repo methods were called
 	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertExpectations(t)
+	mockTaskHistoryRepo.AssertExpectations(t)
 }
 
 func TestRecordUSDCSwapTotalAmountReturnsErrorWhenUserAmountIncrementFails(t *testing.T) {

--- a/services/ethereum_service.go
+++ b/services/ethereum_service.go
@@ -2,11 +2,9 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"strings"
-	"sync"
 	"trading-ace/config"
 	"trading-ace/logger"
 	"trading-ace/models"
@@ -21,6 +19,7 @@ import (
 
 type IEthereumClient interface {
 	SubscribeFilterLogs(context.Context, ethereum.FilterQuery, chan<- types.Log) (ethereum.Subscription, error)
+	TransactionByHash(context.Context, common.Hash) (*types.Transaction, bool, error)
 }
 
 type IEthereumService interface {
@@ -39,6 +38,7 @@ type EthereumService struct {
 
 const wethDecimals int64 = 18
 const usdcDecimals int64 = 6
+const ethereumMainnetChainID int64 = 1
 
 func NewEthereumService(logger logger.ILogger, config *config.Config, campaignService ICampaignService) IEthereumService {
 	return &EthereumService{
@@ -83,7 +83,7 @@ func (e *EthereumService) SubscribeEthereumSwap(ctx context.Context) error {
 				continue
 			}
 
-			err = e.processSwapEvent(ctx, event)
+			err = e.processSwapEvent(ctx, client, event)
 			if err != nil {
 				e.logger.Error(err)
 			}
@@ -187,64 +187,74 @@ func (e *EthereumService) retrieveEventData(vLog types.Log, parsedABI IABI) (*mo
 	}
 
 	event.SenderAddress = vLog.Topics[1].Hex()[26:]
+	event.TxHash = vLog.TxHash
 
 	return &event, nil
 }
 
-func (e *EthereumService) processSwapEvent(ctx context.Context, event *models.SwapEvent) error {
+func (e *EthereumService) processSwapEvent(ctx context.Context, client IEthereumClient, event *models.SwapEvent) error {
 	senderAddress := event.SenderAddress
 	e.logger.Info("Sender: %s", senderAddress)
 
 	// Convert amounts to float for easier logging
-	amountInUSDC := new(big.Float).SetInt(event.Amount0In)
-	amountInUSDC.Quo(amountInUSDC, new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(usdcDecimals), nil)))
+	amountInUSDC := tokenAmountFloat(event.Amount0In, usdcDecimals)
 	e.logger.Info("Amount0In (USDC): %s", amountInUSDC.String())
 
-	amountOutUSDC := new(big.Float).SetInt(event.Amount0Out)
-	amountOutUSDC.Quo(amountOutUSDC, new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(usdcDecimals), nil)))
+	amountOutUSDC := tokenAmountFloat(event.Amount0Out, usdcDecimals)
 	e.logger.Info("Amount0Out (USDC): %s", amountOutUSDC.String())
 
-	amountInWETH := new(big.Float).SetInt(event.Amount1In)
-	amountInWETH.Quo(amountInWETH, new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(wethDecimals), nil)))
+	amountInWETH := tokenAmountFloat(event.Amount1In, wethDecimals)
 	e.logger.Info("Amount1In (WETH): %s", amountInWETH.String())
 
-	amountOutWETH := new(big.Float).SetInt(event.Amount1Out)
-	amountOutWETH.Quo(amountOutWETH, new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(wethDecimals), nil)))
+	amountOutWETH := tokenAmountFloat(event.Amount1Out, wethDecimals)
 	e.logger.Info("Amount1Out (WETH): %s", amountOutWETH.String())
 
-	// Record the campaign data asynchronously
 	amountInUSDCFloat64, _ := amountInUSDC.Float64()
 	amountOutUSDCFloat64, _ := amountOutUSDC.Float64()
-
-	var wg sync.WaitGroup
-	errCh := make(chan error, 2)
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		_, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, event.SenderAddress, amountInUSDCFloat64)
-		errCh <- err
-	}()
-
-	go func() {
-		defer wg.Done()
-		_, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, event.SenderAddress, amountOutUSDCFloat64)
-		errCh <- err
-	}()
-
-	wg.Wait()
-	close(errCh)
-
-	var recordErrors []error
-	for err := range errCh {
-		if err != nil {
-			recordErrors = append(recordErrors, err)
-		}
+	usdcAmount := amountInUSDCFloat64 + amountOutUSDCFloat64
+	if usdcAmount == 0 {
+		return nil
 	}
 
-	if err := errors.Join(recordErrors...); err != nil {
+	participantAddress, err := e.resolveTransactionSender(ctx, client, event.TxHash)
+	if err != nil {
+		return err
+	}
+
+	if _, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, participantAddress.Hex(), usdcAmount); err != nil {
 		return fmt.Errorf("failed to record swap event campaign data: %w", err)
 	}
 
 	return nil
+}
+
+func (e *EthereumService) resolveTransactionSender(ctx context.Context, client IEthereumClient, txHash common.Hash) (common.Address, error) {
+	tx, _, err := client.TransactionByHash(ctx, txHash)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to fetch swap transaction %s: %w", txHash.Hex(), err)
+	}
+
+	if tx == nil {
+		return common.Address{}, fmt.Errorf("swap transaction not found: %s", txHash.Hex())
+	}
+
+	signer := types.LatestSignerForChainID(big.NewInt(ethereumMainnetChainID))
+	sender, err := types.Sender(signer, tx)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to recover swap transaction sender %s: %w", txHash.Hex(), err)
+	}
+
+	return sender, nil
+}
+
+func tokenAmountFloat(amount *big.Int, decimals int64) *big.Float {
+	if amount == nil {
+		return big.NewFloat(0)
+	}
+
+	value := new(big.Float).SetInt(amount)
+	denominator := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(decimals), nil))
+	value.Quo(value, denominator)
+
+	return value
 }

--- a/services/ethereum_service_test.go
+++ b/services/ethereum_service_test.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseABI(t *testing.T) {
@@ -105,6 +107,7 @@ func TestRetrieveEventData(t *testing.T) {
 	assert.Equal(t, event.Amount1In, expectedEvent.Amount1In)
 	assert.Equal(t, event.Amount0Out, expectedEvent.Amount0Out)
 	assert.Equal(t, event.Amount1Out, expectedEvent.Amount1Out)
+	assert.Equal(t, vLog.TxHash, event.TxHash)
 
 	// Verify that UnpackIntoInterface was called with correct parameters
 	mockABI.AssertExpectations(t)
@@ -117,12 +120,17 @@ func TestProcessSwapEvent(t *testing.T) {
 	// Set up mocks
 	mockLogger := new(mocks.MockLogger)
 	mockCampaignService := new(mocks.MockCampaignService)
+	mockClient := new(mocks.MockEthereumClient)
+	ctx := context.WithValue(context.Background(), struct{}{}, "swap-context")
+	txHash := common.HexToHash("0x1234")
+	signedTx, transactionSender := signedMainnetTransaction(t)
 
 	// Mock logger behavior
 	mockLogger.On("Info", mock.Anything).Return()
 
 	// Mock RecordUSDCSwapTotalAmount behavior
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything).Return(100.0, nil)
+	mockClient.On("TransactionByHash", sameContext(ctx), txHash).Return(signedTx, false, nil).Once()
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), transactionSender.Hex(), 0.00002).Return(100.0, nil).Once()
 
 	// Create EthereumService instance
 	e := &EthereumService{
@@ -131,7 +139,8 @@ func TestProcessSwapEvent(t *testing.T) {
 	}
 
 	event := &models.SwapEvent{
-		SenderAddress: "0xSenderAddress",
+		SenderAddress: "0xRouterAddress",
+		TxHash:        txHash,
 		Amount0In:     big.NewInt(10),
 		Amount0Out:    big.NewInt(10),
 		Amount1In:     big.NewInt(10),
@@ -139,24 +148,30 @@ func TestProcessSwapEvent(t *testing.T) {
 	}
 
 	// Test processSwapEvent
-	err := e.processSwapEvent(context.Background(), event)
+	err := e.processSwapEvent(ctx, mockClient, event)
 	assert.NoError(t, err, "expected no error")
 
 	// Verify expectations
 	mockLogger.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
 	mockCampaignService.AssertExpectations(t)
 
 	// Additional assertions for verifying specific behaviors
-	mockCampaignService.AssertCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything)
+	mockCampaignService.AssertNumberOfCalls(t, "RecordUSDCSwapTotalAmount", 1)
 }
 
 func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 	mockLogger := new(mocks.MockLogger)
 	mockCampaignService := new(mocks.MockCampaignService)
+	mockClient := new(mocks.MockEthereumClient)
+	ctx := context.Background()
+	txHash := common.HexToHash("0xabcd")
+	signedTx, transactionSender := signedMainnetTransaction(t)
 
 	mockLogger.On("Info", mock.Anything).Return()
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, "0xSenderAddress", mock.Anything).
-		Return(0.0, fmt.Errorf("record failed"))
+	mockClient.On("TransactionByHash", mock.Anything, txHash).Return(signedTx, false, nil).Once()
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, transactionSender.Hex(), 0.00002).
+		Return(0.0, fmt.Errorf("record failed")).Once()
 
 	e := &EthereumService{
 		logger:          mockLogger,
@@ -164,16 +179,137 @@ func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 	}
 
 	event := &models.SwapEvent{
-		SenderAddress: "0xSenderAddress",
+		SenderAddress: "0xRouterAddress",
+		TxHash:        txHash,
 		Amount0In:     big.NewInt(10),
 		Amount0Out:    big.NewInt(10),
 		Amount1In:     big.NewInt(10),
 		Amount1Out:    big.NewInt(10),
 	}
 
-	err := e.processSwapEvent(context.Background(), event)
+	err := e.processSwapEvent(ctx, mockClient, event)
 
 	assert.ErrorContains(t, err, "record failed")
 	mockLogger.AssertExpectations(t)
+	mockClient.AssertExpectations(t)
 	mockCampaignService.AssertExpectations(t)
+}
+
+func TestProcessSwapEventRecordsTransactionSenderOnceWithCombinedUSDCAmount(t *testing.T) {
+	mockLogger := new(mocks.MockLogger)
+	mockCampaignService := new(mocks.MockCampaignService)
+	mockClient := new(mocks.MockEthereumClient)
+	ctx := context.WithValue(context.Background(), struct{}{}, "participant-context")
+	txHash := common.HexToHash("0xbeef")
+	signedTx, transactionSender := signedMainnetTransaction(t)
+
+	mockLogger.On("Info", mock.Anything).Return()
+	mockClient.On("TransactionByHash", sameContext(ctx), txHash).Return(signedTx, false, nil).Once()
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), transactionSender.Hex(), 1000.0).
+		Return(1000.0, nil).Once()
+
+	e := &EthereumService{
+		logger:          mockLogger,
+		campaignService: mockCampaignService,
+	}
+
+	event := &models.SwapEvent{
+		SenderAddress: "0x000000000000000000000000000000000000dEaD",
+		TxHash:        txHash,
+		Amount0In:     big.NewInt(250_000000),
+		Amount0Out:    big.NewInt(750_000000),
+		Amount1In:     big.NewInt(0),
+		Amount1Out:    big.NewInt(0),
+	}
+
+	err := e.processSwapEvent(ctx, mockClient, event)
+
+	assert.NoError(t, err)
+	mockCampaignService.AssertExpectations(t)
+	mockCampaignService.AssertNumberOfCalls(t, "RecordUSDCSwapTotalAmount", 1)
+	mockClient.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestProcessSwapEventSkipsZeroUSDCAmount(t *testing.T) {
+	mockLogger := new(mocks.MockLogger)
+	mockCampaignService := new(mocks.MockCampaignService)
+	mockClient := new(mocks.MockEthereumClient)
+	txHash := common.HexToHash("0xcafe")
+
+	mockLogger.On("Info", mock.Anything).Return()
+
+	e := &EthereumService{
+		logger:          mockLogger,
+		campaignService: mockCampaignService,
+	}
+
+	event := &models.SwapEvent{
+		SenderAddress: "0x000000000000000000000000000000000000dEaD",
+		TxHash:        txHash,
+		Amount0In:     big.NewInt(0),
+		Amount0Out:    big.NewInt(0),
+		Amount1In:     big.NewInt(10),
+		Amount1Out:    big.NewInt(10),
+	}
+
+	err := e.processSwapEvent(context.Background(), mockClient, event)
+
+	assert.NoError(t, err)
+	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything)
+	mockClient.AssertNotCalled(t, "TransactionByHash", mock.Anything, mock.Anything)
+	mockLogger.AssertExpectations(t)
+}
+
+func TestProcessSwapEventReturnsErrorWhenTransactionIsMissing(t *testing.T) {
+	mockLogger := new(mocks.MockLogger)
+	mockCampaignService := new(mocks.MockCampaignService)
+	mockClient := new(mocks.MockEthereumClient)
+	txHash := common.HexToHash("0xfeed")
+
+	mockLogger.On("Info", mock.Anything).Return()
+	mockClient.On("TransactionByHash", mock.Anything, txHash).Return(nil, false, nil).Once()
+
+	e := &EthereumService{
+		logger:          mockLogger,
+		campaignService: mockCampaignService,
+	}
+
+	event := &models.SwapEvent{
+		SenderAddress: "0x000000000000000000000000000000000000dEaD",
+		TxHash:        txHash,
+		Amount0In:     big.NewInt(1),
+		Amount0Out:    big.NewInt(0),
+		Amount1In:     big.NewInt(0),
+		Amount1Out:    big.NewInt(0),
+	}
+
+	err := e.processSwapEvent(context.Background(), mockClient, event)
+
+	assert.ErrorContains(t, err, "swap transaction not found")
+	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything)
+	mockClient.AssertExpectations(t)
+	mockLogger.AssertExpectations(t)
+}
+
+func signedMainnetTransaction(t *testing.T) (*types.Transaction, common.Address) {
+	t.Helper()
+
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	transactionSender := crypto.PubkeyToAddress(privateKey.PublicKey)
+	tx := types.NewTransaction(
+		0,
+		common.HexToAddress("0x0000000000000000000000000000000000000001"),
+		big.NewInt(0),
+		21_000,
+		big.NewInt(1),
+		nil,
+	)
+
+	signedTx, err := types.SignTx(tx, types.LatestSignerForChainID(big.NewInt(1)), privateKey)
+	require.NoError(t, err)
+
+	return signedTx, transactionSender
 }


### PR DESCRIPTION
## Summary
- Resolve swap reward participant from the Ethereum transaction sender instead of the Uniswap pair event sender.
- Record USDC volume once per swap by combining `amount0In + amount0Out`, and skip zero-USDC events.
- Propagate Redis task cache decode/set failures and tighten task status repository query behavior.
- Document the remaining `tx.from` attribution limitation for aggregators and smart contract wallets.

## Test Plan
- `go test ./...`
- `go build ./...`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `git diff --check`