### PR TITLE
Make share pool settlement DB-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Uniswap USDC/WETH Swap event
   -> USDC amount extraction
   -> Campaign service
   -> Redis volume accumulation
+  -> Hourly DB-driven settlement worker
   -> Reward calculation
   -> PostgreSQL task histories
   -> Campaign APIs
@@ -34,7 +35,7 @@ PostgreSQL is used for durable campaign records: task definitions and completed 
 
 ## Main Components
 
-- `main.go`: application wiring, database/Redis setup, Gin server startup.
+- `main.go`: application wiring, database/Redis setup, Gin server startup, hourly settlement worker startup.
 - `services/ethereum_service.go`: Infura connection, Uniswap swap subscription, event parsing.
 - `services/campaign_service.go`: campaign initialization, volume tracking, reward calculation, leaderboard reads.
 - `repositories/`: PostgreSQL access for tasks and task histories.
@@ -161,6 +162,7 @@ Implemented:
 - Real Ethereum event subscription for the USDC/WETH Uniswap V2 pool.
 - Campaign task initialization.
 - Redis volume accumulation.
+- DB-driven share-pool settlement state and hourly settlement worker.
 - PostgreSQL task history persistence.
 - Leaderboard API backed by Redis sorted sets.
 - Dockerized local services and CI tests.
@@ -170,8 +172,6 @@ Not production-ready yet:
 - Event listener reconnect/backoff behavior.
 - Historical backfill and event deduplication.
 - Participant attribution uses transaction sender (`tx.from`); aggregators and smart contract wallets may require deeper trace-based attribution.
-- Durable settlement worker state.
-- Multi-instance locking for reward settlement.
 - Automated database migrations during container startup.
 - Secrets management beyond local YAML configuration.
 - Multi-pool or multi-campaign configuration.
@@ -180,11 +180,10 @@ Not production-ready yet:
 
 If this prototype were extended into a production service, the next steps would be:
 
-1. Replace the in-memory weekly ticker with a DB-driven settlement worker.
-2. Track settlement status per task period to prevent duplicate reward distribution.
-3. Store last processed block and support historical backfill.
-4. Add reconnect/backoff handling for Ethereum subscriptions.
-5. Add event deduplication based on transaction hash and log index.
-6. Automate migrations as part of deployment.
-7. Move secrets to environment variables or a secret manager.
-8. Add integration tests covering API, PostgreSQL, and Redis together.
+1. Store last processed block and support historical backfill.
+2. Add reconnect/backoff handling for Ethereum subscriptions.
+3. Add event deduplication based on transaction hash and log index.
+4. Add settlement retry visibility, alerting, and operator controls.
+5. Automate migrations as part of deployment.
+6. Move secrets to environment variables or a secret manager.
+7. Add integration tests covering API, PostgreSQL, and Redis together.

--- a/entities/task.go
+++ b/entities/task.go
@@ -12,4 +12,7 @@ type Task struct {
 	Period      int        `db:"period"`      // INT DEFAULT 1
 	CreatedAt   time.Time  `db:"created_at"`  // TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 	UpdatedAt   time.Time  `db:"updated_at"`  // TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+	SettlementStartedAt *time.Time `db:"settlement_started_at"` // TIMESTAMP NULL
+	SettledAt           *time.Time `db:"settled_at"`            // TIMESTAMP NULL
 }

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 )
 
 const startupTimeout = 10 * time.Second
+const settlementWorkerInterval = time.Hour
 
 func NewDB(config *config.Config) (*sql.DB, error) {
 	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
@@ -136,6 +137,47 @@ func SetupServer(
 	})
 }
 
+func SetupSettlementWorker(
+	lc fx.Lifecycle,
+	appCtx context.Context,
+	logger logger.ILogger,
+	campaignService services.ICampaignService,
+) {
+	settlementCtx, cancelSettlement := context.WithCancel(appCtx)
+
+	lc.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			go runSettlementWorker(settlementCtx, logger, campaignService, settlementWorkerInterval)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			cancelSettlement()
+			return nil
+		},
+	})
+}
+
+func runSettlementWorker(
+	ctx context.Context,
+	logger logger.ILogger,
+	campaignService services.ICampaignService,
+	interval time.Duration,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := campaignService.SettleDueSharePoolTasks(ctx); err != nil {
+				logger.Error("Share pool settlement worker failed: %v", err)
+			}
+		}
+	}
+}
+
 func main() {
 	app := fx.New(
 		fx.StartTimeout(startupTimeout),
@@ -169,7 +211,10 @@ func main() {
 			helpers.NewRedisHelper,
 			NewAppContext,
 		),
-		fx.Invoke(SetupServer),
+		fx.Invoke(
+			SetupServer,
+			SetupSettlementWorker,
+		),
 	)
 
 	app.Run()

--- a/main_test.go
+++ b/main_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 	"time"
 	"trading-ace/config"
+	"trading-ace/mocks"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx/fxtest"
 )
@@ -49,6 +51,33 @@ func TestNewAppContextCancelsOnLifecycleStop(t *testing.T) {
 
 	require.NoError(t, lifecycle.Stop(contextWithTimeout(t)))
 	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestRunSettlementWorkerRunsOnInterval(t *testing.T) {
+	campaignService := new(mocks.MockCampaignService)
+	loggerMock := new(mocks.MockLogger)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	settled := make(chan struct{})
+
+	campaignService.On("SettleDueSharePoolTasks", mock.Anything).
+		Run(func(mock.Arguments) {
+			close(settled)
+			cancel()
+		}).
+		Return(nil).
+		Once()
+
+	go runSettlementWorker(ctx, loggerMock, campaignService, 5*time.Millisecond)
+
+	select {
+	case <-settled:
+	case <-time.After(time.Second):
+		t.Fatal("settlement worker did not run")
+	}
+
+	campaignService.AssertExpectations(t)
+	loggerMock.AssertExpectations(t)
 }
 
 func contextWithTimeout(t *testing.T) context.Context {

--- a/migrations/202606081805_add_task_settlement_status.down.sql
+++ b/migrations/202606081805_add_task_settlement_status.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS tasks_unsettled_share_pool_idx;
+
+ALTER TABLE tasks
+DROP COLUMN IF EXISTS settlement_started_at,
+DROP COLUMN IF EXISTS settled_at;

--- a/migrations/202606081805_add_task_settlement_status.up.sql
+++ b/migrations/202606081805_add_task_settlement_status.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE tasks
+ADD COLUMN settlement_started_at TIMESTAMP NULL,
+ADD COLUMN settled_at TIMESTAMP NULL;
+
+CREATE INDEX tasks_unsettled_share_pool_idx
+ON tasks (end_at, settlement_started_at)
+WHERE name = 'SharePoolTask' AND settled_at IS NULL;

--- a/mocks/campaign_service.go
+++ b/mocks/campaign_service.go
@@ -46,3 +46,8 @@ func (m *MockCampaignService) GetLeaderboard(ctx context.Context, taskName strin
 	args := m.Called(ctx, taskName, period)
 	return args.Get(0).([]models.LeaderboardEntry), args.Error(1)
 }
+
+func (m *MockCampaignService) SettleDueSharePoolTasks(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}

--- a/mocks/task_history_repository.go
+++ b/mocks/task_history_repository.go
@@ -17,6 +17,11 @@ func (m *MockTaskHistoryRepository) Create(ctx context.Context, taskHistory *ent
 	return getTaskHistory(args, 0), args.Error(1)
 }
 
+func (m *MockTaskHistoryRepository) Upsert(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
+	args := m.Called(ctx, taskHistory)
+	return getTaskHistory(args, 0), args.Error(1)
+}
+
 func (m *MockTaskHistoryRepository) FindByID(ctx context.Context, id int64) (*entities.TaskHistory, error) {
 	args := m.Called(ctx, id)
 	return getTaskHistory(args, 0), args.Error(1)

--- a/mocks/task_repository.go
+++ b/mocks/task_repository.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"time"
 	"trading-ace/entities"
 	"trading-ace/models"
 
@@ -40,4 +41,28 @@ func (m *MockTaskRepository) IsExistedByName(ctx context.Context, name string) (
 func (m *MockTaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error) {
 	args := m.Called(ctx, address, names)
 	return args.Get(0).([]*models.TaskWithTaskHistory), args.Error(1)
+}
+
+func (m *MockTaskRepository) ClaimDueSharePoolTask(ctx context.Context, now time.Time) (*entities.Task, error) {
+	args := m.Called(ctx, now)
+	return getTask(args, 0), args.Error(1)
+}
+
+func (m *MockTaskRepository) MarkSettled(ctx context.Context, id int64, claimStartedAt time.Time, settledAt time.Time) error {
+	args := m.Called(ctx, id, claimStartedAt, settledAt)
+	return args.Error(0)
+}
+
+func (m *MockTaskRepository) ReleaseSettlementClaim(ctx context.Context, id int64, claimStartedAt time.Time) error {
+	args := m.Called(ctx, id, claimStartedAt)
+	return args.Error(0)
+}
+
+func getTask(args mock.Arguments, index int) *entities.Task {
+	value := args.Get(index)
+	if value == nil {
+		return nil
+	}
+
+	return value.(*entities.Task)
 }

--- a/repositories/task_history_repository.go
+++ b/repositories/task_history_repository.go
@@ -10,6 +10,7 @@ import (
 
 type ITaskHistoryRepository interface {
 	Create(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error)
+	Upsert(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error)
 	FindByID(ctx context.Context, id int64) (*entities.TaskHistory, error)
 	FindByAddressAndTaskId(ctx context.Context, address string, taskId int64) (*entities.TaskHistory, error)
 	GetByAddressIncludingTasks(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error)
@@ -46,6 +47,35 @@ func (r *TaskHistoryRepository) Create(ctx context.Context, taskHistory *entitie
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task record: %w", err)
+	}
+
+	return &result, nil
+}
+
+func (r *TaskHistoryRepository) Upsert(ctx context.Context, taskHistory *entities.TaskHistory) (*entities.TaskHistory, error) {
+	query := `
+		INSERT INTO task_histories (address, task_id, reward_points, amount, completed_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		ON CONFLICT (address, task_id) DO UPDATE
+		SET reward_points = EXCLUDED.reward_points,
+			amount = EXCLUDED.amount,
+			completed_at = EXCLUDED.completed_at,
+			updated_at = CURRENT_TIMESTAMP
+		RETURNING id, address, task_id, reward_points, amount, completed_at, created_at, updated_at
+	`
+
+	var result entities.TaskHistory
+	err := r.db.QueryRowContext(
+		ctx,
+		query,
+		taskHistory.Address, taskHistory.TaskID, taskHistory.RewardPoints,
+		taskHistory.Amount, taskHistory.CompletedAt,
+	).Scan(
+		&result.ID, &result.Address, &result.TaskID, &result.RewardPoints,
+		&result.Amount, &result.CompletedAt, &result.CreatedAt, &result.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to upsert task record: %w", err)
 	}
 
 	return &result, nil

--- a/repositories/task_history_repository_test.go
+++ b/repositories/task_history_repository_test.go
@@ -44,6 +44,34 @@ func TestCreateTaskHistory(t *testing.T) {
 	assert.Equal(t, taskHistory.Address, createdTaskHistory.Address)
 }
 
+func TestUpsertTaskHistoryUpdatesExistingAddressTaskPair(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskHistoryRepository(db)
+	completedAt := time.Now().UTC()
+	taskHistory := &entities.TaskHistory{
+		Address:      "test_address",
+		TaskID:       1,
+		RewardPoints: 10.5,
+		Amount:       100.0,
+		CompletedAt:  &completedAt,
+	}
+
+	mock.ExpectQuery(`ON CONFLICT \(address, task_id\) DO UPDATE`).
+		WithArgs(taskHistory.Address, taskHistory.TaskID, taskHistory.RewardPoints, taskHistory.Amount, taskHistory.CompletedAt).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "address", "task_id", "reward_points", "amount", "completed_at", "created_at", "updated_at"}).
+			AddRow(1, taskHistory.Address, taskHistory.TaskID, taskHistory.RewardPoints, taskHistory.Amount, taskHistory.CompletedAt, time.Now(), time.Now()))
+
+	result, err := repo.Upsert(context.Background(), taskHistory)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, taskHistory.Address, result.Address)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestFindByID(t *testing.T) {
 	// 設置 mock 資料庫
 	db, mock, err := sqlmock.New()

--- a/repositories/task_repository.go
+++ b/repositories/task_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 	"trading-ace/entities"
 	"trading-ace/models"
 )
@@ -16,6 +17,9 @@ type ITaskRepository interface {
 	GetByName(ctx context.Context, name string) ([]*entities.Task, error)
 	IsExistedByName(ctx context.Context, name string) (bool, error)
 	GetByAddressAndNamesIncludingTaskHistories(ctx context.Context, address string, names []string) ([]*models.TaskWithTaskHistory, error)
+	ClaimDueSharePoolTask(ctx context.Context, now time.Time) (*entities.Task, error)
+	MarkSettled(ctx context.Context, id int64, claimStartedAt time.Time, settledAt time.Time) error
+	ReleaseSettlementClaim(ctx context.Context, id int64, claimStartedAt time.Time) error
 }
 
 type TaskRepository struct {
@@ -213,4 +217,90 @@ func (t *TaskRepository) GetByAddressAndNamesIncludingTaskHistories(ctx context.
 	}
 
 	return results, nil
+}
+
+func (t *TaskRepository) ClaimDueSharePoolTask(ctx context.Context, now time.Time) (*entities.Task, error) {
+	query := `
+		UPDATE tasks
+		SET settlement_started_at = $2, updated_at = CURRENT_TIMESTAMP
+		WHERE id = (
+			SELECT id
+			FROM tasks
+			WHERE name = $1
+				AND end_at <= $2
+				AND settled_at IS NULL
+				AND (
+					settlement_started_at IS NULL
+					OR settlement_started_at <= $2 - INTERVAL '2 hours'
+				)
+			ORDER BY end_at, period
+			LIMIT 1
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, name, description, points, started_at, end_at, period, created_at, updated_at,
+			settlement_started_at, settled_at
+	`
+
+	task := &entities.Task{}
+	err := t.db.QueryRowContext(ctx, query, "SharePoolTask", now).Scan(
+		&task.ID, &task.Name, &task.Description, &task.Points,
+		&task.StartedAt, &task.EndAt, &task.Period,
+		&task.CreatedAt, &task.UpdatedAt,
+		&task.SettlementStartedAt, &task.SettledAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to claim due share pool task: %w", err)
+	}
+
+	return task, nil
+}
+
+func (t *TaskRepository) MarkSettled(ctx context.Context, id int64, claimStartedAt time.Time, settledAt time.Time) error {
+	query := `
+		UPDATE tasks
+		SET settled_at = $3, updated_at = CURRENT_TIMESTAMP
+		WHERE id = $1 AND settlement_started_at = $2 AND settled_at IS NULL
+	`
+
+	result, err := t.db.ExecContext(ctx, query, id, claimStartedAt, settledAt)
+	if err != nil {
+		return fmt.Errorf("failed to mark task settled: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check settled task update result: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("settlement claim does not match task %d", id)
+	}
+
+	return nil
+}
+
+func (t *TaskRepository) ReleaseSettlementClaim(ctx context.Context, id int64, claimStartedAt time.Time) error {
+	query := `
+		UPDATE tasks
+		SET settlement_started_at = NULL, updated_at = CURRENT_TIMESTAMP
+		WHERE id = $1 AND settlement_started_at = $2 AND settled_at IS NULL
+	`
+
+	result, err := t.db.ExecContext(ctx, query, id, claimStartedAt)
+	if err != nil {
+		return fmt.Errorf("failed to release settlement claim: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check settlement claim release result: %w", err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("settlement claim does not match task %d", id)
+	}
+
+	return nil
 }

--- a/repositories/task_repository_test.go
+++ b/repositories/task_repository_test.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"regexp"
 	"testing"
@@ -322,4 +323,129 @@ func TestGetByAddressAndNamesIncludingTaskHistoriesReturnsErrorForEmptyNames(t *
 
 	assert.Nil(t, results)
 	assert.ErrorContains(t, err, "task names cannot be empty")
+}
+
+func TestClaimDueSharePoolTaskClaimsOneDueUnsettledTask(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	now := time.Now().UTC()
+	startedAt := now.Add(-7 * 24 * time.Hour)
+	endAt := now.Add(-time.Hour)
+
+	mock.ExpectQuery(`UPDATE tasks`).
+		WithArgs("SharePoolTask", now).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "description", "points", "started_at", "end_at", "period", "created_at", "updated_at",
+			"settlement_started_at", "settled_at",
+		}).AddRow(
+			7, "SharePoolTask", "SharePoolTask", 10000, startedAt, endAt, 2, now, now,
+			now, nil,
+		))
+
+	task, err := repo.ClaimDueSharePoolTask(context.Background(), now)
+
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, int64(7), task.ID)
+	assert.Equal(t, "SharePoolTask", task.Name)
+	assert.Equal(t, 2, task.Period)
+	assert.Equal(t, &now, task.SettlementStartedAt)
+	assert.Nil(t, task.SettledAt)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestClaimDueSharePoolTaskReturnsNilWhenNoTaskIsDue(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	now := time.Now().UTC()
+
+	mock.ExpectQuery(`UPDATE tasks`).
+		WithArgs("SharePoolTask", now).
+		WillReturnError(sql.ErrNoRows)
+
+	task, err := repo.ClaimDueSharePoolTask(context.Background(), now)
+
+	assert.NoError(t, err)
+	assert.Nil(t, task)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMarkSettled(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	settledAt := time.Now().UTC()
+	claimStartedAt := settledAt.Add(-time.Minute)
+
+	mock.ExpectExec(`UPDATE tasks`).
+		WithArgs(int64(7), claimStartedAt, settledAt).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = repo.MarkSettled(context.Background(), 7, claimStartedAt, settledAt)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMarkSettledReturnsErrorWhenClaimDoesNotMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	settledAt := time.Now().UTC()
+	claimStartedAt := settledAt.Add(-time.Minute)
+
+	mock.ExpectExec(`UPDATE tasks`).
+		WithArgs(int64(7), claimStartedAt, settledAt).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repo.MarkSettled(context.Background(), 7, claimStartedAt, settledAt)
+
+	assert.ErrorContains(t, err, "settlement claim does not match")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReleaseSettlementClaim(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	claimStartedAt := time.Now().UTC()
+
+	mock.ExpectExec(`UPDATE tasks`).
+		WithArgs(int64(7), claimStartedAt).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = repo.ReleaseSettlementClaim(context.Background(), 7, claimStartedAt)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReleaseSettlementClaimReturnsErrorWhenClaimDoesNotMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer db.Close()
+
+	repo := NewTaskRepository(db)
+	claimStartedAt := time.Now().UTC()
+
+	mock.ExpectExec(`UPDATE tasks`).
+		WithArgs(int64(7), claimStartedAt).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = repo.ReleaseSettlementClaim(context.Background(), 7, claimStartedAt)
+
+	assert.ErrorContains(t, err, "settlement claim does not match")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/services/campaign_service.go
+++ b/services/campaign_service.go
@@ -3,10 +3,10 @@ package services
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 	"trading-ace/config"
 	"trading-ace/entities"
@@ -26,17 +26,15 @@ type ICampaignService interface {
 	FindOnboardingTask(ctx context.Context) (*entities.Task, error)
 	FindCurrentSharePoolTask(ctx context.Context) (*entities.Task, error)
 	GetLeaderboard(ctx context.Context, taskName string, period int) ([]models.LeaderboardEntry, error)
+	SettleDueSharePoolTasks(ctx context.Context) error
 }
 
 type CampaignService struct {
-	config           *config.Config
-	logger           logger.ILogger
-	taskHistoryRepo  repositories.ITaskHistoryRepository
-	taskRepo         repositories.ITaskRepository
-	redisHelper      helpers.IRedisHelper
-	schedulerMu      sync.Mutex
-	schedulerStarted bool
-	workerCtx        context.Context
+	config          *config.Config
+	logger          logger.ILogger
+	taskHistoryRepo repositories.ITaskHistoryRepository
+	taskRepo        repositories.ITaskRepository
+	redisHelper     helpers.IRedisHelper
 }
 
 const OnboardingTaskStr string = "OnboardingTask"
@@ -55,7 +53,6 @@ func NewCampaignService(
 	taskHistoryRepo repositories.ITaskHistoryRepository,
 	taskRepo repositories.ITaskRepository,
 	redisHelper helpers.IRedisHelper,
-	workerCtx context.Context,
 ) ICampaignService {
 	return &CampaignService{
 		config:          config,
@@ -63,7 +60,6 @@ func NewCampaignService(
 		taskHistoryRepo: taskHistoryRepo,
 		taskRepo:        taskRepo,
 		redisHelper:     redisHelper,
-		workerCtx:       workerCtx,
 	}
 }
 
@@ -72,12 +68,9 @@ func (s *CampaignService) StartCampaign(ctx context.Context) error {
 		return err
 	}
 
-	shareTasks, err := s.createSharePoolTask(ctx)
-	if err != nil {
+	if _, err := s.createSharePoolTask(ctx); err != nil {
 		return err
 	}
-
-	s.startLimitedWeeklySettlementScheduler(shareTasks)
 
 	return nil
 }
@@ -333,44 +326,6 @@ func (s *CampaignService) cacheTask(ctx context.Context, key string, task *entit
 	return nil
 }
 
-func (s *CampaignService) startLimitedWeeklySettlementScheduler(tasks []*entities.Task) {
-	s.schedulerMu.Lock()
-	if s.schedulerStarted {
-		s.schedulerMu.Unlock()
-		return
-	}
-	s.schedulerStarted = true
-	s.schedulerMu.Unlock()
-
-	ticker := time.NewTicker(7 * 24 * time.Hour)
-	maxRuns := 4
-	runCount := 0
-
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case <-s.workerCtx.Done():
-				s.logger.Info("Weekly settlement scheduler stopped: %v", s.workerCtx.Err())
-				return
-			case <-ticker.C:
-				if runCount >= maxRuns {
-					s.logger.Info("Weekly settlement scheduler reached its limit, stopping...")
-					return
-				}
-
-				if err := s.calculateSharePoolPoint(s.workerCtx, tasks[runCount]); err != nil {
-					s.logger.Error("Failed to perform weekly settlement: %v", err)
-				}
-
-				runCount++
-			}
-		}
-	}()
-
-	s.logger.Info("Limited weekly settlement scheduler started")
-}
-
 func (s *CampaignService) calculateSharePoolPoint(ctx context.Context, task *entities.Task) error {
 	if task.Name != SharePoolTaskStr {
 		return fmt.Errorf("task is not shard pool task")
@@ -379,24 +334,31 @@ func (s *CampaignService) calculateSharePoolPoint(ctx context.Context, task *ent
 	key := fmt.Sprintf("%s_%d", task.Name, task.Period)
 	totalKey := fmt.Sprintf("%s_total", key)
 
-	totalStr, err := s.redisHelper.Get(ctx, totalKey)
-	if err != nil {
-		return err
-	}
-
-	totalAmount, err := strconv.ParseFloat(totalStr, 64)
-	if err != nil {
-		return fmt.Errorf("failed to parse total amount from key %s: %w", totalKey, err)
-	}
-
 	swapAmountMap, err := s.redisHelper.HGetAll(ctx, key)
 	if err != nil {
 		return err
 	}
 
+	if len(swapAmountMap) == 0 {
+		return nil
+	}
+
+	totalStr, err := s.redisHelper.Get(ctx, totalKey)
+	if err != nil {
+		return err
+	}
+	totalAmount, err := strconv.ParseFloat(totalStr, 64)
+	if err != nil {
+		return fmt.Errorf("failed to parse total amount from key %s: %w", totalKey, err)
+	}
+	if totalAmount <= 0 {
+		return fmt.Errorf("total amount for key %s must be greater than zero", totalKey)
+	}
+
 	taskPoints := task.Points
 
 	now := time.Now().UTC()
+	var settlementErrors []error
 	for address, v := range swapAmountMap {
 		amount, err := strconv.ParseFloat(v, 64)
 		if err != nil {
@@ -416,15 +378,60 @@ func (s *CampaignService) calculateSharePoolPoint(ctx context.Context, task *ent
 			UpdatedAt:    now,
 		}
 
-		if _, err := s.taskHistoryRepo.Create(ctx, history); err != nil {
-			s.logger.Error("create history failed for address %s, %v", address, err)
+		if _, err := s.taskHistoryRepo.Upsert(ctx, history); err != nil {
+			settlementErrors = append(settlementErrors, fmt.Errorf("upsert history failed for address %s: %w", address, err))
 			continue
 		}
 
-		s.redisHelper.ZAdd(ctx, fmt.Sprintf("%s_rank", key), &redis.Z{Score: rewards, Member: address})
+		if err := s.redisHelper.ZAdd(ctx, fmt.Sprintf("%s_rank", key), &redis.Z{Score: rewards, Member: address}); err != nil {
+			settlementErrors = append(settlementErrors, fmt.Errorf("update leaderboard failed for address %s: %w", address, err))
+		}
+	}
+
+	if err := errors.Join(settlementErrors...); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (s *CampaignService) SettleDueSharePoolTasks(ctx context.Context) error {
+	for {
+		task, err := s.taskRepo.ClaimDueSharePoolTask(ctx, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if task == nil {
+			return nil
+		}
+
+		if task.SettlementStartedAt == nil {
+			return fmt.Errorf("claimed share pool task %d is missing settlement_started_at", task.ID)
+		}
+		claimStartedAt := *task.SettlementStartedAt
+
+		if err := s.calculateSharePoolPoint(ctx, task); err != nil {
+			if releaseErr := s.taskRepo.ReleaseSettlementClaim(ctx, task.ID, claimStartedAt); releaseErr != nil {
+				return errors.Join(
+					fmt.Errorf("failed to settle share pool task %d: %w", task.ID, err),
+					fmt.Errorf("failed to release settlement claim for task %d: %w", task.ID, releaseErr),
+				)
+			}
+
+			return fmt.Errorf("failed to settle share pool task %d: %w", task.ID, err)
+		}
+
+		if err := s.taskRepo.MarkSettled(ctx, task.ID, claimStartedAt, time.Now().UTC()); err != nil {
+			if releaseErr := s.taskRepo.ReleaseSettlementClaim(ctx, task.ID, claimStartedAt); releaseErr != nil {
+				return errors.Join(
+					fmt.Errorf("failed to mark share pool task %d settled: %w", task.ID, err),
+					fmt.Errorf("failed to release settlement claim for task %d: %w", task.ID, releaseErr),
+				)
+			}
+
+			return fmt.Errorf("failed to mark share pool task %d settled: %w", task.ID, err)
+		}
+	}
 }
 
 func (s *CampaignService) GetLeaderboard(ctx context.Context, taskName string, period int) ([]models.LeaderboardEntry, error) {

--- a/services/campaign_service_test.go
+++ b/services/campaign_service_test.go
@@ -46,7 +46,7 @@ func TestGetPointHistories(t *testing.T) {
 	// 設置 mock 返回值
 	taskHistoryRepoMock.On("GetByAddressIncludingTasks", mock.Anything, "address1").Return(taskHistoryMock, nil)
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	result, err := svc.GetPointHistories(context.Background(), "address1")
 
 	// 驗證結果
@@ -80,7 +80,7 @@ func TestGetTaskStatus(t *testing.T) {
 	taskRepoMock.On("GetByAddressAndNamesIncludingTaskHistories", mock.Anything, "address1", []string{OnboardingTaskStr, SharePoolTaskStr}).
 		Return(taskWithHistoryMock, nil)
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	result, err := svc.GetTaskStatus(context.Background(), "address1")
 
 	// 驗證結果
@@ -107,7 +107,7 @@ func TestGetTaskStatusPropagatesContextToRepository(t *testing.T) {
 		[]string{OnboardingTaskStr, SharePoolTaskStr},
 	).Return([]*models.TaskWithTaskHistory{}, nil).Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	result, err := svc.GetTaskStatus(ctx, "address1")
 
 	assert.NoError(t, err)
@@ -130,11 +130,8 @@ func TestStartCampaign(t *testing.T) {
 	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{}, nil)
 	taskRepoMock.On("Create", mock.Anything, mock.Anything).Return(&entities.Task{}, nil)
 
-	// 模擬 logger 的行為
-	loggerMock.On("Info", mock.Anything).Return()
-
 	// 呼叫 StartCampaign 方法
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	err := svc.StartCampaign(context.Background())
 
 	// 驗證結果
@@ -148,8 +145,7 @@ func TestStartCampaign(t *testing.T) {
 	taskRepoMock.AssertCalled(t, "GetByName", mock.Anything, SharePoolTaskStr)
 	taskRepoMock.AssertCalled(t, "Create", mock.Anything, mock.Anything)
 
-	// 驗證 logger 是否有記錄啟動計劃
-	loggerMock.AssertCalled(t, "Info", mock.Anything)
+	loggerMock.AssertNotCalled(t, "Info", mock.Anything)
 }
 
 func TestStartCampaignReturnsNoErrorWhenCampaignTasksAlreadyExist(t *testing.T) {
@@ -168,15 +164,14 @@ func TestStartCampaignReturnsNoErrorWhenCampaignTasksAlreadyExist(t *testing.T) 
 
 	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
 	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
-	loggerMock.On("Info", mock.Anything).Return().Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	err := svc.StartCampaign(context.Background())
 
 	assert.NoError(t, err)
 	taskRepoMock.AssertNotCalled(t, "Create", mock.Anything)
 	taskRepoMock.AssertExpectations(t)
-	loggerMock.AssertExpectations(t)
+	loggerMock.AssertNotCalled(t, "Info", mock.Anything)
 }
 
 func TestStartCampaignReturnsErrorWhenExistingSharePoolTasksAreIncomplete(t *testing.T) {
@@ -194,7 +189,7 @@ func TestStartCampaignReturnsErrorWhenExistingSharePoolTasksAreIncomplete(t *tes
 	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
 	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(incompleteSharePoolTasks, nil).Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 	err := svc.StartCampaign(context.Background())
 
 	assert.Error(t, err)
@@ -204,7 +199,7 @@ func TestStartCampaignReturnsErrorWhenExistingSharePoolTasksAreIncomplete(t *tes
 	loggerMock.AssertExpectations(t)
 }
 
-func TestStartCampaignDoesNotStartDuplicateScheduler(t *testing.T) {
+func TestStartCampaignDoesNotStartSettlementWorker(t *testing.T) {
 	cfg := &config.Config{}
 	loggerMock := &mocks.MockLogger{}
 	taskHistoryRepoMock := &mocks.MockTaskHistoryRepository{}
@@ -221,19 +216,143 @@ func TestStartCampaignDoesNotStartDuplicateScheduler(t *testing.T) {
 	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(false, nil).Once()
 	taskRepoMock.On("Create", mock.Anything, mock.Anything).Return(&entities.Task{}, nil).Times(5)
 	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{}, nil).Once()
-	loggerMock.On("Info", mock.Anything).Return().Once()
 
 	taskRepoMock.On("IsExistedByName", mock.Anything, OnboardingTaskStr).Return(true, nil).Once()
 	taskRepoMock.On("GetByName", mock.Anything, SharePoolTaskStr).Return(existingSharePoolTasks, nil).Once()
 
-	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock, context.Background())
+	svc := NewCampaignService(cfg, loggerMock, taskHistoryRepoMock, taskRepoMock, redisHelperMock)
 
 	assert.NoError(t, svc.StartCampaign(context.Background()))
 	assert.NoError(t, svc.StartCampaign(context.Background()))
 
 	taskRepoMock.AssertNumberOfCalls(t, "Create", 5)
-	loggerMock.AssertNumberOfCalls(t, "Info", 1)
+	loggerMock.AssertNotCalled(t, "Info", mock.Anything)
 	taskRepoMock.AssertExpectations(t)
+}
+
+func TestSettleDueSharePoolTasksClaimsDueTaskAndMarksSettled(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
+	loggerMock := new(mocks.MockLogger)
+	ctx := context.WithValue(context.Background(), struct{}{}, "settlement-context")
+	claimStartedAt := time.Now().UTC()
+	dueTask := &entities.Task{
+		ID:                  7,
+		Name:                SharePoolTaskStr,
+		Period:              2,
+		Points:              SharePoolTaskPoints,
+		SettlementStartedAt: &claimStartedAt,
+	}
+	key := "SharePoolTask_2"
+
+	service := &CampaignService{
+		logger:          loggerMock,
+		redisHelper:     mockRedisHelper,
+		taskRepo:        mockTaskRepo,
+		taskHistoryRepo: mockTaskHistoryRepo,
+	}
+
+	mockTaskRepo.On("ClaimDueSharePoolTask", sameContext(ctx), mock.AnythingOfType("time.Time")).
+		Return(dueTask, nil).Once()
+	mockRedisHelper.On("HGetAll", sameContext(ctx), key).Return(map[string]string{
+		"0xA": "1000",
+		"0xB": "3000",
+	}, nil).Once()
+	mockRedisHelper.On("Get", sameContext(ctx), key+"_total").Return("4000", nil).Once()
+	mockTaskHistoryRepo.On("Upsert", sameContext(ctx), mock.AnythingOfType("*entities.TaskHistory")).
+		Return(&entities.TaskHistory{}, nil).Twice()
+	mockRedisHelper.On("ZAdd", sameContext(ctx), key+"_rank", mock.Anything).Return(nil).Twice()
+	mockTaskRepo.On("MarkSettled", sameContext(ctx), dueTask.ID, claimStartedAt, mock.AnythingOfType("time.Time")).
+		Return(nil).Once()
+	mockTaskRepo.On("ClaimDueSharePoolTask", sameContext(ctx), mock.AnythingOfType("time.Time")).
+		Return(nil, nil).Once()
+
+	err := service.SettleDueSharePoolTasks(ctx)
+
+	assert.NoError(t, err)
+	mockTaskRepo.AssertExpectations(t)
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskHistoryRepo.AssertExpectations(t)
+	loggerMock.AssertExpectations(t)
+}
+
+func TestSettleDueSharePoolTasksReleasesClaimWhenCalculationFails(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
+	loggerMock := new(mocks.MockLogger)
+	ctx := context.Background()
+	claimStartedAt := time.Now().UTC()
+	dueTask := &entities.Task{
+		ID:                  7,
+		Name:                SharePoolTaskStr,
+		Period:              2,
+		Points:              SharePoolTaskPoints,
+		SettlementStartedAt: &claimStartedAt,
+	}
+	key := "SharePoolTask_2"
+
+	service := &CampaignService{
+		logger:          loggerMock,
+		redisHelper:     mockRedisHelper,
+		taskRepo:        mockTaskRepo,
+		taskHistoryRepo: mockTaskHistoryRepo,
+	}
+
+	mockTaskRepo.On("ClaimDueSharePoolTask", mock.Anything, mock.AnythingOfType("time.Time")).
+		Return(dueTask, nil).Once()
+	mockRedisHelper.On("HGetAll", mock.Anything, key).Return(map[string]string{"0xA": "1000"}, nil).Once()
+	mockRedisHelper.On("Get", mock.Anything, key+"_total").Return("", errors.New("missing total")).Once()
+	mockTaskRepo.On("ReleaseSettlementClaim", mock.Anything, dueTask.ID, claimStartedAt).Return(nil).Once()
+
+	err := service.SettleDueSharePoolTasks(ctx)
+
+	assert.ErrorContains(t, err, "missing total")
+	mockTaskRepo.AssertExpectations(t)
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskHistoryRepo.AssertExpectations(t)
+	loggerMock.AssertExpectations(t)
+}
+
+func TestSettleDueSharePoolTasksMarksNoVolumeTaskSettled(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
+	loggerMock := new(mocks.MockLogger)
+	ctx := context.Background()
+	claimStartedAt := time.Now().UTC()
+	dueTask := &entities.Task{
+		ID:                  7,
+		Name:                SharePoolTaskStr,
+		Period:              2,
+		Points:              SharePoolTaskPoints,
+		SettlementStartedAt: &claimStartedAt,
+	}
+	key := "SharePoolTask_2"
+
+	service := &CampaignService{
+		logger:          loggerMock,
+		redisHelper:     mockRedisHelper,
+		taskRepo:        mockTaskRepo,
+		taskHistoryRepo: mockTaskHistoryRepo,
+	}
+
+	mockTaskRepo.On("ClaimDueSharePoolTask", mock.Anything, mock.AnythingOfType("time.Time")).
+		Return(dueTask, nil).Once()
+	mockRedisHelper.On("HGetAll", mock.Anything, key).Return(map[string]string{}, nil).Once()
+	mockTaskRepo.On("MarkSettled", mock.Anything, dueTask.ID, claimStartedAt, mock.AnythingOfType("time.Time")).
+		Return(nil).Once()
+	mockTaskRepo.On("ClaimDueSharePoolTask", mock.Anything, mock.AnythingOfType("time.Time")).
+		Return(nil, nil).Once()
+
+	err := service.SettleDueSharePoolTasks(ctx)
+
+	assert.NoError(t, err)
+	mockTaskRepo.AssertExpectations(t)
+	mockRedisHelper.AssertExpectations(t)
+	mockRedisHelper.AssertNotCalled(t, "Get", mock.Anything, key+"_total")
+	mockTaskHistoryRepo.AssertExpectations(t)
 	loggerMock.AssertExpectations(t)
 }
 
@@ -461,7 +580,6 @@ func TestRecordUSDCSwapTotalAmountPropagatesContextToDependencies(t *testing.T) 
 		redisHelper:     mockRedisHelper,
 		taskRepo:        mockTaskRepo,
 		taskHistoryRepo: mockTaskHistoryRepo,
-		workerCtx:       context.Background(),
 	}
 
 	now := time.Now()


### PR DESCRIPTION
## Summary
- Decouple share-pool settlement from `/campaign/start`; campaign start now only initializes tasks.
- Add DB settlement state (`settlement_started_at`, `settled_at`) and repository methods to atomically claim, release, and mark due share-pool tasks.
- Start a lifecycle-managed settlement worker that checks for due share-pool tasks every 1 hour.
- Update README to reflect the DB-driven settlement flow and remaining roadmap.

## Test Plan
- `go test ./... -count=1`
- `go build ./...`
- `go vet ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `git diff --check`