### PR TITLE
fix: deduplicate swap volume events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Uniswap USDC/WETH Swap event
   -> Transaction sender lookup
   -> USDC amount extraction
   -> Campaign service
-  -> Redis volume accumulation
+  -> Redis atomic event deduplication and volume accumulation
   -> Hourly DB-driven settlement worker
   -> Reward calculation
   -> PostgreSQL task histories
   -> Campaign APIs
 ```
 
-Redis is used for fast-changing campaign state: per-period swap totals, per-user accumulated volume, current task cache, and leaderboard sorted sets.
+Redis is used for fast-changing campaign state: per-period swap totals, per-user accumulated volume, atomic swap event deduplication by `chain_id + tx_hash + log_index`, current task cache, and leaderboard sorted sets.
 
 PostgreSQL is used for durable campaign records: task definitions and completed task histories.
 
@@ -39,7 +39,7 @@ PostgreSQL is used for durable campaign records: task definitions and completed 
 - `services/ethereum_service.go`: Infura connection, Uniswap swap subscription, event parsing.
 - `services/campaign_service.go`: campaign initialization, volume tracking, reward calculation, leaderboard reads.
 - `repositories/`: PostgreSQL access for tasks and task histories.
-- `helpers/redis_helper.go`: Redis key/value, hash, and sorted set operations.
+- `helpers/redis_helper.go`: Redis key/value, hash, sorted set, and atomic swap volume operations.
 - `controllers/` and `routes/`: HTTP API surface.
 - `migrations/`: PostgreSQL schema setup.
 
@@ -161,7 +161,7 @@ Implemented:
 
 - Real Ethereum event subscription for the USDC/WETH Uniswap V2 pool.
 - Campaign task initialization.
-- Redis volume accumulation.
+- Redis-backed swap event deduplication and volume accumulation.
 - DB-driven share-pool settlement state and hourly settlement worker.
 - PostgreSQL task history persistence.
 - Leaderboard API backed by Redis sorted sets.
@@ -170,7 +170,7 @@ Implemented:
 Not production-ready yet:
 
 - Event listener reconnect/backoff behavior.
-- Historical backfill and event deduplication.
+- Historical backfill and durable processed-event audit storage.
 - Participant attribution uses transaction sender (`tx.from`); aggregators and smart contract wallets may require deeper trace-based attribution.
 - Automated database migrations during container startup.
 - Secrets management beyond local YAML configuration.
@@ -182,7 +182,7 @@ If this prototype were extended into a production service, the next steps would 
 
 1. Store last processed block and support historical backfill.
 2. Add reconnect/backoff handling for Ethereum subscriptions.
-3. Add event deduplication based on transaction hash and log index.
+3. Persist processed-event audit records and expose recovery tooling around backfill.
 4. Add settlement retry visibility, alerting, and operator controls.
 5. Automate migrations as part of deployment.
 6. Move secrets to environment variables or a secret manager.

--- a/helpers/redis_helper.go
+++ b/helpers/redis_helper.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 	"trading-ace/config"
 
@@ -18,6 +19,7 @@ type IRedisHelper interface {
 	HGet(ctx context.Context, key string, field string) (string, error)
 	HGetAll(ctx context.Context, key string) (map[string]string, error)
 	HIncrFloat(ctx context.Context, key string, field string, value float64) error
+	RecordSwapVolumeOnce(ctx context.Context, eventKey string, volumeKey string, totalKey string, address string, amount float64, expiration time.Duration) (float64, bool, error)
 	ZAdd(ctx context.Context, key string, members ...*redis.Z) error
 	ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)
 	ZRangeWithScores(ctx context.Context, key string, start, stop int64) ([]string, []float64, error)
@@ -30,6 +32,48 @@ type RedisHelper struct {
 	redisClient *redis.Client
 	prefix      string
 }
+
+const recordSwapVolumeOnceScript = `
+if redis.call("EXISTS", KEYS[1]) == 1 then
+	return {0, "0"}
+end
+
+local amount = tonumber(ARGV[2])
+if amount == nil then
+	return redis.error_reply("invalid swap amount")
+end
+
+local ttl_seconds = tonumber(ARGV[3])
+if ttl_seconds == nil or ttl_seconds < 1 then
+	return redis.error_reply("invalid swap event ttl")
+end
+
+local volume_key_type = redis.call("TYPE", KEYS[2]).ok
+if volume_key_type ~= "none" and volume_key_type ~= "hash" then
+	return redis.error_reply("invalid swap volume key type")
+end
+
+local total_key_type = redis.call("TYPE", KEYS[3]).ok
+if total_key_type ~= "none" and total_key_type ~= "string" then
+	return redis.error_reply("invalid swap total key type")
+end
+
+local current_address_total = redis.call("HGET", KEYS[2], ARGV[1])
+if current_address_total ~= false and tonumber(current_address_total) == nil then
+	return redis.error_reply("invalid address swap total")
+end
+
+local current_total = redis.call("GET", KEYS[3])
+if current_total ~= false and tonumber(current_total) == nil then
+	return redis.error_reply("invalid swap total")
+end
+
+redis.call("SET", KEYS[1], "1", "EX", ttl_seconds)
+local address_total = redis.call("HINCRBYFLOAT", KEYS[2], ARGV[1], ARGV[2])
+redis.call("INCRBYFLOAT", KEYS[3], ARGV[2])
+
+return {1, address_total}
+`
 
 func NewRedisHelper(redisClient *redis.Client, config *config.Config) IRedisHelper {
 	return &RedisHelper{
@@ -116,6 +160,79 @@ func (r *RedisHelper) HIncrFloat(ctx context.Context, key string, field string, 
 	}
 
 	return nil
+}
+
+func (r *RedisHelper) RecordSwapVolumeOnce(ctx context.Context, eventKey string, volumeKey string, totalKey string, address string, amount float64, expiration time.Duration) (float64, bool, error) {
+	ttlSeconds := int64(expiration.Seconds())
+	if ttlSeconds < 1 {
+		ttlSeconds = 1
+	}
+
+	result, err := r.redisClient.Eval(
+		ctx,
+		recordSwapVolumeOnceScript,
+		[]string{r.prefix + eventKey, r.prefix + volumeKey, r.prefix + totalKey},
+		address,
+		amount,
+		ttlSeconds,
+	).Result()
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to record swap volume once: %w", err)
+	}
+
+	values, ok := result.([]interface{})
+	if !ok || len(values) != 2 {
+		return 0, false, fmt.Errorf("unexpected swap volume record result: %v", result)
+	}
+
+	recordedFlag, err := redisResultInt64(values[0])
+	if err != nil {
+		return 0, false, fmt.Errorf("unexpected swap volume recorded flag: %w", err)
+	}
+	if recordedFlag != 0 && recordedFlag != 1 {
+		return 0, false, fmt.Errorf("unexpected swap volume recorded flag: %d", recordedFlag)
+	}
+
+	totalAmount, err := redisResultFloat64(values[1])
+	if err != nil {
+		return 0, false, fmt.Errorf("unexpected swap volume total amount: %w", err)
+	}
+
+	return totalAmount, recordedFlag == 1, nil
+}
+
+func redisResultInt64(value interface{}) (int64, error) {
+	switch v := value.(type) {
+	case int:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case string:
+		return strconv.ParseInt(v, 10, 64)
+	case []byte:
+		return strconv.ParseInt(string(v), 10, 64)
+	default:
+		return 0, fmt.Errorf("unsupported type %T", value)
+	}
+}
+
+func redisResultFloat64(value interface{}) (float64, error) {
+	switch v := value.(type) {
+	case float32:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	case []byte:
+		return strconv.ParseFloat(string(v), 64)
+	default:
+		return 0, fmt.Errorf("unsupported type %T", value)
+	}
 }
 
 func (r *RedisHelper) ZAdd(ctx context.Context, key string, members ...*redis.Z) error {

--- a/helpers/redis_helper_test.go
+++ b/helpers/redis_helper_test.go
@@ -163,6 +163,82 @@ func TestRedisHelper_HIncrFloat(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRedisHelper_RecordSwapVolumeOnceRecordsFirstEvent(t *testing.T) {
+	r, mock := setupRedisHelper()
+
+	eventKey := "swap_event:1:0xbeef:12"
+	volumeKey := "SharePoolTask_1"
+	totalKey := "SharePoolTask_1_total"
+	address := "0x123"
+	amount := 125.5
+	expiration := time.Hour
+
+	mock.ExpectEval(
+		recordSwapVolumeOnceScript,
+		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
+		address,
+		amount,
+		int64(expiration.Seconds()),
+	).SetVal([]interface{}{int64(1), "125.5"})
+
+	totalAmount, recorded, err := r.RecordSwapVolumeOnce(context.Background(), eventKey, volumeKey, totalKey, address, amount, expiration)
+
+	assert.NoError(t, err)
+	assert.True(t, recorded)
+	assert.Equal(t, 125.5, totalAmount)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRedisHelper_RecordSwapVolumeOnceSkipsDuplicateEvent(t *testing.T) {
+	r, mock := setupRedisHelper()
+
+	eventKey := "swap_event:1:0xbeef:12"
+	volumeKey := "SharePoolTask_1"
+	totalKey := "SharePoolTask_1_total"
+	address := "0x123"
+	amount := 125.5
+	expiration := time.Hour
+
+	mock.ExpectEval(
+		recordSwapVolumeOnceScript,
+		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
+		address,
+		amount,
+		int64(expiration.Seconds()),
+	).SetVal([]interface{}{int64(0), "0"})
+
+	totalAmount, recorded, err := r.RecordSwapVolumeOnce(context.Background(), eventKey, volumeKey, totalKey, address, amount, expiration)
+
+	assert.NoError(t, err)
+	assert.False(t, recorded)
+	assert.Equal(t, 0.0, totalAmount)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRedisHelper_RecordSwapVolumeOnceReturnsEvalError(t *testing.T) {
+	r, mock := setupRedisHelper()
+
+	eventKey := "swap_event:1:0xbeef:12"
+	volumeKey := "SharePoolTask_1"
+	totalKey := "SharePoolTask_1_total"
+	address := "0x123"
+	amount := 125.5
+	expiration := time.Hour
+
+	mock.ExpectEval(
+		recordSwapVolumeOnceScript,
+		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
+		address,
+		amount,
+		int64(expiration.Seconds()),
+	).SetErr(errors.New("redis eval failed"))
+
+	_, _, err := r.RecordSwapVolumeOnce(context.Background(), eventKey, volumeKey, totalKey, address, amount, expiration)
+
+	assert.ErrorContains(t, err, "redis eval failed")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestRedisHelper_ZAdd(t *testing.T) {
 	r, mock := setupRedisHelper()
 

--- a/mocks/campaign_service.go
+++ b/mocks/campaign_service.go
@@ -22,8 +22,8 @@ func (m *MockCampaignService) GetPointHistories(ctx context.Context, address str
 	return args.Get(0).([]*models.TaskTaskHistoryPair), args.Error(1)
 }
 
-func (m *MockCampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error) {
-	args := m.Called(ctx, senderAddress, amount)
+func (m *MockCampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, eventID string, senderAddress string, amount float64) (float64, error) {
+	args := m.Called(ctx, eventID, senderAddress, amount)
 	return args.Get(0).(float64), args.Error(1)
 }
 

--- a/mocks/redis_helper.go
+++ b/mocks/redis_helper.go
@@ -53,6 +53,11 @@ func (m *MockRedisHelper) HIncrFloat(ctx context.Context, key string, field stri
 	return args.Error(0)
 }
 
+func (m *MockRedisHelper) RecordSwapVolumeOnce(ctx context.Context, eventKey string, volumeKey string, totalKey string, address string, amount float64, expiration time.Duration) (float64, bool, error) {
+	args := m.Called(ctx, eventKey, volumeKey, totalKey, address, amount, expiration)
+	return args.Get(0).(float64), args.Bool(1), args.Error(2)
+}
+
 func (m *MockRedisHelper) ZAdd(ctx context.Context, key string, members ...*redis.Z) error {
 	args := m.Called(ctx, key, members)
 	return args.Error(0)

--- a/models/swap_event.go
+++ b/models/swap_event.go
@@ -9,6 +9,7 @@ import (
 type SwapEvent struct {
 	SenderAddress string
 	TxHash        common.Hash
+	LogIndex      uint
 	Amount0In     *big.Int
 	Amount1In     *big.Int
 	Amount0Out    *big.Int

--- a/services/campaign_service.go
+++ b/services/campaign_service.go
@@ -21,7 +21,7 @@ import (
 type ICampaignService interface {
 	StartCampaign(ctx context.Context) error
 	GetPointHistories(ctx context.Context, address string) ([]*models.TaskTaskHistoryPair, error)
-	RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error)
+	RecordUSDCSwapTotalAmount(ctx context.Context, eventID string, senderAddress string, amount float64) (float64, error)
 	GetTaskStatus(ctx context.Context, address string) ([]*models.TaskWithTaskHistory, error)
 	FindOnboardingTask(ctx context.Context) (*entities.Task, error)
 	FindCurrentSharePoolTask(ctx context.Context) (*entities.Task, error)
@@ -46,6 +46,7 @@ const SharePoolTaskStr string = "SharePoolTask"
 const SharePoolTaskDescription string = "SharePoolTask"
 const SharePoolTaskPoints float64 = 10000
 const SharePoolTaskPeriods int = 4
+const processedSwapEventRetention time.Duration = 30 * 24 * time.Hour
 
 func NewCampaignService(
 	config *config.Config,
@@ -83,7 +84,7 @@ func (s *CampaignService) GetTaskStatus(ctx context.Context, address string) ([]
 	return s.taskRepo.GetByAddressAndNamesIncludingTaskHistories(ctx, address, []string{OnboardingTaskStr, SharePoolTaskStr})
 }
 
-func (s *CampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderAddress string, amount float64) (float64, error) {
+func (s *CampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, eventID string, senderAddress string, amount float64) (float64, error) {
 	// find current share task
 	task, err := s.FindCurrentSharePoolTask(ctx)
 	if err != nil {
@@ -91,23 +92,14 @@ func (s *CampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderA
 	}
 
 	key := fmt.Sprintf("%s_%d", task.Name, task.Period)
-	if err := s.redisHelper.HIncrFloat(ctx, key, senderAddress, amount); err != nil {
-		return 0, fmt.Errorf("failed to increment address swap amount: %w", err)
-	}
-
-	totalAmountStr, err := s.redisHelper.HGet(ctx, key, senderAddress)
-	if err != nil {
-		return 0, err
-	}
-
 	totalKey := fmt.Sprintf("%s_total", key)
-	if err := s.redisHelper.IncrFloat(ctx, totalKey, amount); err != nil {
-		return 0, fmt.Errorf("failed to increment total swap amount: %w", err)
+	totalAmount, recorded, err := s.redisHelper.RecordSwapVolumeOnce(ctx, eventID, key, totalKey, senderAddress, amount, swapEventDedupExpiration(task, time.Now().UTC()))
+	if err != nil {
+		return 0, fmt.Errorf("failed to record swap amount: %w", err)
 	}
 
-	totalAmount, err := strconv.ParseFloat(totalAmountStr, 64)
-	if err != nil {
-		return 0, err
+	if !recorded {
+		return 0, nil
 	}
 
 	// if amount is not enough
@@ -141,6 +133,19 @@ func (s *CampaignService) RecordUSDCSwapTotalAmount(ctx context.Context, senderA
 	}
 
 	return totalAmount, nil
+}
+
+func swapEventDedupExpiration(task *entities.Task, now time.Time) time.Duration {
+	if task == nil || task.EndAt == nil {
+		return processedSwapEventRetention
+	}
+
+	expiration := task.EndAt.Sub(now) + processedSwapEventRetention
+	if expiration < time.Second {
+		return time.Second
+	}
+
+	return expiration
 }
 
 func (s *CampaignService) createOnboardingTask(ctx context.Context) error {

--- a/services/campaign_service_test.go
+++ b/services/campaign_service_test.go
@@ -512,21 +512,20 @@ func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 		EndAt:     ptrTime(now.Add(time.Hour)),
 		Period:    1,
 	}
-	totalAmountStr := "100.0"
+	eventID := "swap_event:1:0xabc:1"
 	key := "SharePoolTask_1"
 
 	// Mock Redis responses
 	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
 	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", mock.Anything, key, senderAddress, amount).Return(nil)
-	mockRedisHelper.On("HGet", mock.Anything, key, senderAddress).Return(totalAmountStr, nil)
-	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", amount).Return(nil)
+	mockRedisHelper.On("RecordSwapVolumeOnce", mock.Anything, eventID, key, key+"_total", senderAddress, amount, mock.Anything).
+		Return(amount, true, nil)
 
 	// Mock FindCurrentSharePoolTask response
 	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
 
 	// Call the method under test
-	totalAmountReturned, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), senderAddress, amount)
+	totalAmountReturned, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), eventID, senderAddress, amount)
 
 	// Assert the results
 	assert.NoError(t, err)
@@ -538,7 +537,43 @@ func TestRecordUSDCSwapTotalAmount(t *testing.T) {
 	mockTaskHistoryRepo.AssertExpectations(t)
 }
 
-func TestRecordUSDCSwapTotalAmountReturnsErrorWhenUserAmountIncrementFails(t *testing.T) {
+func TestRecordUSDCSwapTotalAmountSkipsDuplicateSwapEvent(t *testing.T) {
+	mockRedisHelper := new(mocks.MockRedisHelper)
+	mockTaskRepo := new(mocks.MockTaskRepository)
+	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
+
+	campaignService := &CampaignService{
+		redisHelper:     mockRedisHelper,
+		taskRepo:        mockTaskRepo,
+		taskHistoryRepo: mockTaskHistoryRepo,
+	}
+
+	now := time.Now()
+	currentTask := &entities.Task{
+		Name:      SharePoolTaskStr,
+		StartedAt: ptrTime(now.Add(-time.Hour)),
+		EndAt:     ptrTime(now.Add(time.Hour)),
+		Period:    1,
+	}
+	eventID := "swap_event:1:0xabc:1"
+	key := "SharePoolTask_1"
+
+	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss")).Once()
+	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil).Once()
+	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil).Once()
+	mockRedisHelper.On("RecordSwapVolumeOnce", mock.Anything, eventID, key, key+"_total", "0x123", 100.0, mock.Anything).
+		Return(0.0, false, nil).Once()
+
+	totalAmount, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), eventID, "0x123", 100.0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, totalAmount)
+	mockTaskHistoryRepo.AssertNotCalled(t, "FindByAddressAndTaskId", mock.Anything, mock.Anything, mock.Anything)
+	mockRedisHelper.AssertExpectations(t)
+	mockTaskRepo.AssertExpectations(t)
+}
+
+func TestRecordUSDCSwapTotalAmountReturnsErrorWhenSwapVolumeRecordFails(t *testing.T) {
 	mockRedisHelper := new(mocks.MockRedisHelper)
 	mockTaskRepo := new(mocks.MockTaskRepository)
 	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
@@ -555,18 +590,18 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenUserAmountIncrementFails(t *te
 		StartedAt: &now,
 		EndAt:     ptrTime(now.Add(time.Hour)),
 	}
+	eventID := "swap_event:1:0xabc:1"
 	key := "SharePoolTask_1"
 
 	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
 	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
 	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 100.0).Return(errors.New("redis hincr failed"))
-	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("100", nil).Maybe()
-	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 100.0).Return(nil).Maybe()
+	mockRedisHelper.On("RecordSwapVolumeOnce", mock.Anything, eventID, key, key+"_total", "0x123", 100.0, mock.Anything).
+		Return(0.0, false, errors.New("redis record failed"))
 
-	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 100.0)
+	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), eventID, "0x123", 100.0)
 
-	assert.ErrorContains(t, err, "redis hincr failed")
+	assert.ErrorContains(t, err, "redis record failed")
 	mockRedisHelper.AssertExpectations(t)
 	mockTaskRepo.AssertExpectations(t)
 }
@@ -589,52 +624,19 @@ func TestRecordUSDCSwapTotalAmountPropagatesContextToDependencies(t *testing.T) 
 		StartedAt: &now,
 		EndAt:     ptrTime(now.Add(time.Hour)),
 	}
+	eventID := "swap_event:1:0xabc:1"
 	key := "SharePoolTask_1"
 
 	mockRedisHelper.On("Get", sameContext(ctx), "curr_shared_pool_task").Return("", errors.New("cache miss")).Once()
 	mockTaskRepo.On("GetByName", sameContext(ctx), SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil).Once()
 	mockRedisHelper.On("Set", sameContext(ctx), "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil).Once()
-	mockRedisHelper.On("HIncrFloat", sameContext(ctx), key, "0x123", 100.0).Return(nil).Once()
-	mockRedisHelper.On("HGet", sameContext(ctx), key, "0x123").Return("100", nil).Once()
-	mockRedisHelper.On("IncrFloat", sameContext(ctx), key+"_total", 100.0).Return(nil).Once()
+	mockRedisHelper.On("RecordSwapVolumeOnce", sameContext(ctx), eventID, key, key+"_total", "0x123", 100.0, mock.Anything).
+		Return(100.0, true, nil).Once()
 
-	totalAmount, err := campaignService.RecordUSDCSwapTotalAmount(ctx, "0x123", 100.0)
+	totalAmount, err := campaignService.RecordUSDCSwapTotalAmount(ctx, eventID, "0x123", 100.0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 100.0, totalAmount)
-	mockRedisHelper.AssertExpectations(t)
-	mockTaskRepo.AssertExpectations(t)
-}
-
-func TestRecordUSDCSwapTotalAmountReturnsErrorWhenTotalAmountIncrementFails(t *testing.T) {
-	mockRedisHelper := new(mocks.MockRedisHelper)
-	mockTaskRepo := new(mocks.MockTaskRepository)
-	mockTaskHistoryRepo := new(mocks.MockTaskHistoryRepository)
-	campaignService := &CampaignService{
-		redisHelper:     mockRedisHelper,
-		taskRepo:        mockTaskRepo,
-		taskHistoryRepo: mockTaskHistoryRepo,
-	}
-
-	now := time.Now()
-	currentTask := &entities.Task{
-		Name:      SharePoolTaskStr,
-		Period:    1,
-		StartedAt: &now,
-		EndAt:     ptrTime(now.Add(time.Hour)),
-	}
-	key := "SharePoolTask_1"
-
-	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
-	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
-	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 100.0).Return(nil)
-	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("100", nil)
-	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 100.0).Return(errors.New("redis incr failed"))
-
-	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 100.0)
-
-	assert.ErrorContains(t, err, "redis incr failed")
 	mockRedisHelper.AssertExpectations(t)
 	mockTaskRepo.AssertExpectations(t)
 }
@@ -656,6 +658,7 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenOnboardingHistoryCreateFails(t
 		StartedAt: &now,
 		EndAt:     ptrTime(now.Add(time.Hour)),
 	}
+	eventID := "swap_event:1:0xabc:1"
 	onboardingTask := &entities.Task{
 		ID:    10,
 		Name:  OnboardingTaskStr,
@@ -666,16 +669,15 @@ func TestRecordUSDCSwapTotalAmountReturnsErrorWhenOnboardingHistoryCreateFails(t
 	mockRedisHelper.On("Get", mock.Anything, "curr_shared_pool_task").Return("", errors.New("cache miss"))
 	mockTaskRepo.On("GetByName", mock.Anything, SharePoolTaskStr).Return([]*entities.Task{currentTask}, nil)
 	mockRedisHelper.On("Set", mock.Anything, "curr_shared_pool_task", mock.Anything, mock.Anything).Return(nil)
-	mockRedisHelper.On("HIncrFloat", mock.Anything, key, "0x123", 1000.0).Return(nil)
-	mockRedisHelper.On("HGet", mock.Anything, key, "0x123").Return("1000", nil)
-	mockRedisHelper.On("IncrFloat", mock.Anything, key+"_total", 1000.0).Return(nil)
+	mockRedisHelper.On("RecordSwapVolumeOnce", mock.Anything, eventID, key, key+"_total", "0x123", 1000.0, mock.Anything).
+		Return(1000.0, true, nil)
 	mockRedisHelper.On("Get", mock.Anything, "onboarding_task").Return("", errors.New("cache miss"))
 	mockTaskRepo.On("FindByName", mock.Anything, OnboardingTaskStr).Return(onboardingTask, nil)
 	mockRedisHelper.On("Set", mock.Anything, "onboarding_task", mock.Anything, mock.Anything).Return(nil)
 	mockTaskHistoryRepo.On("FindByAddressAndTaskId", mock.Anything, "0x123", onboardingTask.ID).Return(nil, errors.New("not found"))
 	mockTaskHistoryRepo.On("Create", mock.Anything, mock.Anything).Return(&entities.TaskHistory{}, errors.New("db create failed"))
 
-	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), "0x123", 1000.0)
+	_, err := campaignService.RecordUSDCSwapTotalAmount(context.Background(), eventID, "0x123", 1000.0)
 
 	assert.ErrorContains(t, err, "db create failed")
 	mockRedisHelper.AssertExpectations(t)

--- a/services/ethereum_service.go
+++ b/services/ethereum_service.go
@@ -188,6 +188,7 @@ func (e *EthereumService) retrieveEventData(vLog types.Log, parsedABI IABI) (*mo
 
 	event.SenderAddress = vLog.Topics[1].Hex()[26:]
 	event.TxHash = vLog.TxHash
+	event.LogIndex = vLog.Index
 
 	return &event, nil
 }
@@ -221,11 +222,16 @@ func (e *EthereumService) processSwapEvent(ctx context.Context, client IEthereum
 		return err
 	}
 
-	if _, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, participantAddress.Hex(), usdcAmount); err != nil {
+	eventID := formatSwapEventID(ethereumMainnetChainID, event.TxHash, event.LogIndex)
+	if _, err := e.campaignService.RecordUSDCSwapTotalAmount(ctx, eventID, participantAddress.Hex(), usdcAmount); err != nil {
 		return fmt.Errorf("failed to record swap event campaign data: %w", err)
 	}
 
 	return nil
+}
+
+func formatSwapEventID(chainID int64, txHash common.Hash, logIndex uint) string {
+	return fmt.Sprintf("swap_event:%d:%s:%d", chainID, txHash.Hex(), logIndex)
 }
 
 func (e *EthereumService) resolveTransactionSender(ctx context.Context, client IEthereumClient, txHash common.Hash) (common.Address, error) {

--- a/services/ethereum_service_test.go
+++ b/services/ethereum_service_test.go
@@ -82,7 +82,8 @@ func TestRetrieveEventData(t *testing.T) {
 			{},                                  // Event signature
 			common.HexToHash("0xSenderAddress"), // Sender Address (mocked)
 		},
-		Data: []byte{0x01, 0x02}, // Mock event data (this will be used by ABI unpacking)
+		Data:  []byte{0x01, 0x02}, // Mock event data (this will be used by ABI unpacking)
+		Index: 7,
 	}
 
 	// Create a mock SwapEvent struct (models.SwapEvent)
@@ -108,6 +109,7 @@ func TestRetrieveEventData(t *testing.T) {
 	assert.Equal(t, event.Amount0Out, expectedEvent.Amount0Out)
 	assert.Equal(t, event.Amount1Out, expectedEvent.Amount1Out)
 	assert.Equal(t, vLog.TxHash, event.TxHash)
+	assert.Equal(t, vLog.Index, event.LogIndex)
 
 	// Verify that UnpackIntoInterface was called with correct parameters
 	mockABI.AssertExpectations(t)
@@ -130,7 +132,8 @@ func TestProcessSwapEvent(t *testing.T) {
 
 	// Mock RecordUSDCSwapTotalAmount behavior
 	mockClient.On("TransactionByHash", sameContext(ctx), txHash).Return(signedTx, false, nil).Once()
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), transactionSender.Hex(), 0.00002).Return(100.0, nil).Once()
+	swapEventID := fmt.Sprintf("swap_event:%d:%s:%d", ethereumMainnetChainID, txHash.Hex(), uint(3))
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), swapEventID, transactionSender.Hex(), 0.00002).Return(100.0, nil).Once()
 
 	// Create EthereumService instance
 	e := &EthereumService{
@@ -141,6 +144,7 @@ func TestProcessSwapEvent(t *testing.T) {
 	event := &models.SwapEvent{
 		SenderAddress: "0xRouterAddress",
 		TxHash:        txHash,
+		LogIndex:      3,
 		Amount0In:     big.NewInt(10),
 		Amount0Out:    big.NewInt(10),
 		Amount1In:     big.NewInt(10),
@@ -170,7 +174,8 @@ func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 
 	mockLogger.On("Info", mock.Anything).Return()
 	mockClient.On("TransactionByHash", mock.Anything, txHash).Return(signedTx, false, nil).Once()
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, transactionSender.Hex(), 0.00002).
+	swapEventID := fmt.Sprintf("swap_event:%d:%s:%d", ethereumMainnetChainID, txHash.Hex(), uint(4))
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", mock.Anything, swapEventID, transactionSender.Hex(), 0.00002).
 		Return(0.0, fmt.Errorf("record failed")).Once()
 
 	e := &EthereumService{
@@ -181,6 +186,7 @@ func TestProcessSwapEventReturnsErrorWhenCampaignRecordingFails(t *testing.T) {
 	event := &models.SwapEvent{
 		SenderAddress: "0xRouterAddress",
 		TxHash:        txHash,
+		LogIndex:      4,
 		Amount0In:     big.NewInt(10),
 		Amount0Out:    big.NewInt(10),
 		Amount1In:     big.NewInt(10),
@@ -205,7 +211,8 @@ func TestProcessSwapEventRecordsTransactionSenderOnceWithCombinedUSDCAmount(t *t
 
 	mockLogger.On("Info", mock.Anything).Return()
 	mockClient.On("TransactionByHash", sameContext(ctx), txHash).Return(signedTx, false, nil).Once()
-	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), transactionSender.Hex(), 1000.0).
+	swapEventID := fmt.Sprintf("swap_event:%d:%s:%d", ethereumMainnetChainID, txHash.Hex(), uint(12))
+	mockCampaignService.On("RecordUSDCSwapTotalAmount", sameContext(ctx), swapEventID, transactionSender.Hex(), 1000.0).
 		Return(1000.0, nil).Once()
 
 	e := &EthereumService{
@@ -216,6 +223,7 @@ func TestProcessSwapEventRecordsTransactionSenderOnceWithCombinedUSDCAmount(t *t
 	event := &models.SwapEvent{
 		SenderAddress: "0x000000000000000000000000000000000000dEaD",
 		TxHash:        txHash,
+		LogIndex:      12,
 		Amount0In:     big.NewInt(250_000000),
 		Amount0Out:    big.NewInt(750_000000),
 		Amount1In:     big.NewInt(0),
@@ -256,7 +264,7 @@ func TestProcessSwapEventSkipsZeroUSDCAmount(t *testing.T) {
 	err := e.processSwapEvent(context.Background(), mockClient, event)
 
 	assert.NoError(t, err)
-	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything)
+	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockClient.AssertNotCalled(t, "TransactionByHash", mock.Anything, mock.Anything)
 	mockLogger.AssertExpectations(t)
 }
@@ -287,7 +295,7 @@ func TestProcessSwapEventReturnsErrorWhenTransactionIsMissing(t *testing.T) {
 	err := e.processSwapEvent(context.Background(), mockClient, event)
 
 	assert.ErrorContains(t, err, "swap transaction not found")
-	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything)
+	mockCampaignService.AssertNotCalled(t, "RecordUSDCSwapTotalAmount", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockClient.AssertExpectations(t)
 	mockLogger.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary
- Add swap event identity using `chain_id + tx_hash + log_index`.
- Record swap volume through an atomic Redis Lua script so duplicate events do not increment volume twice.
- Update README to document Redis-backed event deduplication and the remaining production hardening scope.

## Test Plan
- [x] go test ./... -count=1
- [x] go build ./...
- [x] go vet ./...
- [x] git diff --check