### PR TITLE
refactor: embed redis lua script

### DIFF
--- a/helpers/lua/record_swap_volume_once.lua
+++ b/helpers/lua/record_swap_volume_once.lua
@@ -1,0 +1,39 @@
+if redis.call("EXISTS", KEYS[1]) == 1 then
+	return {0, "0"}
+end
+
+local amount = tonumber(ARGV[2])
+if amount == nil then
+	return redis.error_reply("invalid swap amount")
+end
+
+local ttl_seconds = tonumber(ARGV[3])
+if ttl_seconds == nil or ttl_seconds < 1 then
+	return redis.error_reply("invalid swap event ttl")
+end
+
+local volume_key_type = redis.call("TYPE", KEYS[2]).ok
+if volume_key_type ~= "none" and volume_key_type ~= "hash" then
+	return redis.error_reply("invalid swap volume key type")
+end
+
+local total_key_type = redis.call("TYPE", KEYS[3]).ok
+if total_key_type ~= "none" and total_key_type ~= "string" then
+	return redis.error_reply("invalid swap total key type")
+end
+
+local current_address_total = redis.call("HGET", KEYS[2], ARGV[1])
+if current_address_total ~= false and tonumber(current_address_total) == nil then
+	return redis.error_reply("invalid address swap total")
+end
+
+local current_total = redis.call("GET", KEYS[3])
+if current_total ~= false and tonumber(current_total) == nil then
+	return redis.error_reply("invalid swap total")
+end
+
+redis.call("SET", KEYS[1], "1", "EX", ttl_seconds)
+local address_total = redis.call("HINCRBYFLOAT", KEYS[2], ARGV[1], ARGV[2])
+redis.call("INCRBYFLOAT", KEYS[3], ARGV[2])
+
+return {1, address_total}

--- a/helpers/redis_helper.go
+++ b/helpers/redis_helper.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"strconv"
 	"time"
@@ -33,47 +34,10 @@ type RedisHelper struct {
 	prefix      string
 }
 
-const recordSwapVolumeOnceScript = `
-if redis.call("EXISTS", KEYS[1]) == 1 then
-	return {0, "0"}
-end
+//go:embed lua/record_swap_volume_once.lua
+var recordSwapVolumeOnceLua string
 
-local amount = tonumber(ARGV[2])
-if amount == nil then
-	return redis.error_reply("invalid swap amount")
-end
-
-local ttl_seconds = tonumber(ARGV[3])
-if ttl_seconds == nil or ttl_seconds < 1 then
-	return redis.error_reply("invalid swap event ttl")
-end
-
-local volume_key_type = redis.call("TYPE", KEYS[2]).ok
-if volume_key_type ~= "none" and volume_key_type ~= "hash" then
-	return redis.error_reply("invalid swap volume key type")
-end
-
-local total_key_type = redis.call("TYPE", KEYS[3]).ok
-if total_key_type ~= "none" and total_key_type ~= "string" then
-	return redis.error_reply("invalid swap total key type")
-end
-
-local current_address_total = redis.call("HGET", KEYS[2], ARGV[1])
-if current_address_total ~= false and tonumber(current_address_total) == nil then
-	return redis.error_reply("invalid address swap total")
-end
-
-local current_total = redis.call("GET", KEYS[3])
-if current_total ~= false and tonumber(current_total) == nil then
-	return redis.error_reply("invalid swap total")
-end
-
-redis.call("SET", KEYS[1], "1", "EX", ttl_seconds)
-local address_total = redis.call("HINCRBYFLOAT", KEYS[2], ARGV[1], ARGV[2])
-redis.call("INCRBYFLOAT", KEYS[3], ARGV[2])
-
-return {1, address_total}
-`
+var recordSwapVolumeOnceScript = redis.NewScript(recordSwapVolumeOnceLua)
 
 func NewRedisHelper(redisClient *redis.Client, config *config.Config) IRedisHelper {
 	return &RedisHelper{
@@ -168,9 +132,9 @@ func (r *RedisHelper) RecordSwapVolumeOnce(ctx context.Context, eventKey string,
 		ttlSeconds = 1
 	}
 
-	result, err := r.redisClient.Eval(
+	result, err := recordSwapVolumeOnceScript.Run(
 		ctx,
-		recordSwapVolumeOnceScript,
+		r.redisClient,
 		[]string{r.prefix + eventKey, r.prefix + volumeKey, r.prefix + totalKey},
 		address,
 		amount,

--- a/helpers/redis_helper_test.go
+++ b/helpers/redis_helper_test.go
@@ -3,6 +3,8 @@ package helpers
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,6 +165,13 @@ func TestRedisHelper_HIncrFloat(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestRecordSwapVolumeOnceScriptIsEmbeddedFromLuaFile(t *testing.T) {
+	luaSource, err := os.ReadFile("lua/record_swap_volume_once.lua")
+
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(string(luaSource)), strings.TrimSpace(recordSwapVolumeOnceLua))
+}
+
 func TestRedisHelper_RecordSwapVolumeOnceRecordsFirstEvent(t *testing.T) {
 	r, mock := setupRedisHelper()
 
@@ -173,8 +182,8 @@ func TestRedisHelper_RecordSwapVolumeOnceRecordsFirstEvent(t *testing.T) {
 	amount := 125.5
 	expiration := time.Hour
 
-	mock.ExpectEval(
-		recordSwapVolumeOnceScript,
+	mock.ExpectEvalSha(
+		recordSwapVolumeOnceScript.Hash(),
 		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
 		address,
 		amount,
@@ -199,8 +208,8 @@ func TestRedisHelper_RecordSwapVolumeOnceSkipsDuplicateEvent(t *testing.T) {
 	amount := 125.5
 	expiration := time.Hour
 
-	mock.ExpectEval(
-		recordSwapVolumeOnceScript,
+	mock.ExpectEvalSha(
+		recordSwapVolumeOnceScript.Hash(),
 		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
 		address,
 		amount,
@@ -225,8 +234,8 @@ func TestRedisHelper_RecordSwapVolumeOnceReturnsEvalError(t *testing.T) {
 	amount := 125.5
 	expiration := time.Hour
 
-	mock.ExpectEval(
-		recordSwapVolumeOnceScript,
+	mock.ExpectEvalSha(
+		recordSwapVolumeOnceScript.Hash(),
 		[]string{"test:" + eventKey, "test:" + volumeKey, "test:" + totalKey},
 		address,
 		amount,


### PR DESCRIPTION
## Summary
- Move the swap volume Redis Lua script into `helpers/lua/record_swap_volume_once.lua`.
- Embed the Lua source with `go:embed` and execute it through `redis.NewScript(...).Run(...)`.
- Update Redis helper tests to validate the embedded script source and EVALSHA execution path.

## Test Plan
- [x] go test ./... -count=1
- [x] go build ./...
- [x] go vet ./...
- [x] git diff --check